### PR TITLE
create stylesheet for alert-panels

### DIFF
--- a/docs/.vuepress/theme/styles/alert-panels.styl
+++ b/docs/.vuepress/theme/styles/alert-panels.styl
@@ -1,0 +1,31 @@
+.theme-default-content {
+	.custom-block {
+		.custom-block-title {
+			letter-spacing: 0.5px;
+		}
+	}
+
+	.tip {
+		border-left: 4px solid #696d78;
+		background-color: #f2f4f7;
+		color: #34373f;
+	}
+
+	.info {
+		border-left: 4px solid #0e74aa;
+		background-color: #e6f6ff;
+		color: #34373f;
+	}
+
+	.warning {
+		border-left: 4px solid #e7c000;
+		background-color: #fff7d2;
+		color: #34373f;
+	}
+
+	.danger {
+		border-left: 4px solid #a93e3e;
+		background-color: #ffe6e6;
+		color: #a93e3e;
+	}
+}

--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -4,6 +4,7 @@
 @import 'header';
 @import 'sidebar';
 @import 'video';
+@import 'alert-panels';
 
 // apply scrolling by default excluding firefox due to trigger issues
 html.smooth-scroll {


### PR DESCRIPTION
Closes [#402](https://github.com/ipfs/docs/issues/402).

As a side note, I think it makes more sense if note panels becomes info panels. Seeing as the beta only uses tips and notes, I think the styling would look better if tips and and notes look different.