### PR TITLE
fix: removes beta notification from footer.

### DIFF
--- a/docs/.vuepress/theme/components/LegacyCallout.vue
+++ b/docs/.vuepress/theme/components/LegacyCallout.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="legacy-callout">
     <p>
-      <b>This site is in beta. Help us improve it!</b>
+      <b>Help us improve this site!</b>
     </p>
     <section>
       <div class="block">
@@ -29,16 +29,8 @@
               >Give general feedback</a
             >
           </li>
-          <li v-if="$site.themeConfig.betaTestFormUrl">
-            <a :href="$site.themeConfig.betaTestFormUrl" target="_blank"
-              >Become a tester</a
-            >
-          </li>
         </ul>
       </div>
-    </section>
-    <section v-if="legacyUrl" class="legacy-links">
-      <a target="_blank" :href="legacyUrl">View this page on legacy site</a>
     </section>
   </div>
 </template>
@@ -46,7 +38,7 @@
 <script>
 export default {
   computed: {
-    legacyUrl: function() {
+    legacyUrl: function () {
       return this.$frontmatter && this.$frontmatter.legacyUrl
     }
   }

--- a/docs/.vuepress/theme/components/LegacyCallout.vue
+++ b/docs/.vuepress/theme/components/LegacyCallout.vue
@@ -35,16 +35,6 @@
   </div>
 </template>
 
-<script>
-export default {
-  computed: {
-    legacyUrl: function () {
-      return this.$frontmatter && this.$frontmatter.legacyUrl
-    }
-  }
-}
-</script>
-
 <style lang="stylus" scoped>
 .legacy-callout {
   background-color: lighten($badgeTipColor, 95%);


### PR DESCRIPTION
Edited the title text to remove the _beta_ notification. Also removed the _Become a tester_ link.

![image](https://user-images.githubusercontent.com/9611008/82584153-16cf3500-9b62-11ea-9d82-2ee6a97969b1.png)

No doubt this could be reorganized to be prettier, but this does the job right now. Closes ipfs/docs#507