### PR TITLE
Updates 0.5.0 to 0.5.1.

### DIFF
--- a/docs/how-to/command-line-quick-start.md
+++ b/docs/how-to/command-line-quick-start.md
@@ -22,23 +22,23 @@ Installing IPFS is simple, but varies between operating system:
 
 ### Windows
 
-1. Download [`go-ipfs_v0.5.0_windows-386.zip` from GitHub](https://github.com/ipfs/go-ipfs/releases/download/v0.5.0/).
+1. Download [`go-ipfs_v0.5.1_windows-386.zip` from GitHub](https://github.com/ipfs/go-ipfs/releases/download/v0.5.1/).
 
    ```powershell
    cd ~\
-   wget https://github.com/ipfs/go-ipfs/releases/download/v0.5.0/go-ipfs-v0.5.0_windows-386.zip -Outfile go-ipfs-v0.5.0.zip
+   wget https://github.com/ipfs/go-ipfs/releases/download/v0.5.1/go-ipfs-v0.5.1_windows-386.zip -Outfile go-ipfs-v0.5.1.zip
    ```
 
 1. Unzip the file and move it somewhere handy.
 
    ```powershell
-   Expand-Archive -Path go-ipfs-v0.5.0.zip -DestinationPath ~\Apps\go-ipfs_v0.5.0
+   Expand-Archive -Path go-ipfs-v0.5.1.zip -DestinationPath ~\Apps\go-ipfs_v0.5.1
    ```
 
-1. Move into the `go-ipfs_v0.5.0` folder and check that the `ipfs.exe` works:
+1. Move into the `go-ipfs_v0.5.1` folder and check that the `ipfs.exe` works:
 
    ```powershell
-   cd ~\Apps\go-ipfs_v0.5.0\go-ipfs
+   cd ~\Apps\go-ipfs_v0.5.1\go-ipfs
    .\ipfs.exe --version
 
    > ipfs version 0.5.0
@@ -53,13 +53,13 @@ Installing IPFS is simple, but varies between operating system:
 
    > Path
    > ----
-   > C:\Users\Johnny\Apps\go-ipfs_v0.5.0\go-ipfs
+   > C:\Users\Johnny\Apps\go-ipfs_v0.5.1\go-ipfs
    ```
 
 1. Add the address you just copied to PowerShell's `PATH` by adding it to the end of the `profile.ps1` file stored in `Documents\WindowsPowerShell`:
 
    ```powershell
-   Add-Content C:\Users\Johnny\Documents\WindowsPowerShell\profile.ps1 "[System.Environment]::SetEnvironmentVariable('PATH',`$Env:PATH+';;C:\Users\Johnny\Apps\go-ipfs_v0.5.0\go-ipfs')"
+   Add-Content C:\Users\Johnny\Documents\WindowsPowerShell\profile.ps1 "[System.Environment]::SetEnvironmentVariable('PATH',`$Env:PATH+';;C:\Users\Johnny\Apps\go-ipfs_v0.5.1\go-ipfs')"
    ```
 
 1. Close and reopen your PowerShell window. Test that your IPFS path is set correctly by going to your home folder and asking IPFS for the version:
@@ -73,16 +73,16 @@ Installing IPFS is simple, but varies between operating system:
 
 ### macOS
 
-1. Download [`go-ipfs_v0.5.0_darwin-386.tar.gz` from GitHub](https://github.com/ipfs/go-ipfs/releases/tag/v0.5.0).
+1. Download [`go-ipfs_v0.5.1_darwin-386.tar.gz` from GitHub](https://github.com/ipfs/go-ipfs/releases/tag/v0.5.1).
 
    ```bash
-   wget https://github.com/ipfs/go-ipfs/releases/download/v0.5.0/go-ipfs_v0.5.0_darwin-amd64.tar.gz
+   wget https://github.com/ipfs/go-ipfs/releases/download/v0.5.1/go-ipfs_v0.5.1_darwin-amd64.tar.gz
    ```
 
 1. Unzip the file:
 
    ```bash
-   tar -xvzf go-ipfs_v0.5.0_darwin-amd64.tar.gz
+   tar -xvzf go-ipfs_v0.5.1_darwin-amd64.tar.gz
 
    > x go-ipfs/install.sh
    > x go-ipfs/ipfs
@@ -110,16 +110,16 @@ Installing IPFS is simple, but varies between operating system:
 
 ### Linux
 
-1. Download [`go-ipfs_v0.5.0_linux-amd64.tar.gz` from GitHub](https://github.com/ipfs/go-ipfs/releases/tag/v0.5.0):
+1. Download [`go-ipfs_v0.5.1_linux-amd64.tar.gz` from GitHub](https://github.com/ipfs/go-ipfs/releases/tag/v0.5.1):
 
    ```bash
-   wget https://github.com/ipfs/go-ipfs/releases/download/v0.5.0/go-ipfs_v0.5.0_linux-amd64.tar.gz
+   wget https://github.com/ipfs/go-ipfs/releases/download/v0.5.1/go-ipfs_v0.5.1_linux-amd64.tar.gz
    ```
 
 1. Unzip the file:
 
    ```bash
-   tar -xvzf go-ipfs_v0.5.0_linux-amd64.tar.gz
+   tar -xvzf go-ipfs_v0.5.1_linux-amd64.tar.gz
 
    > x go-ipfs/install.sh
    > x go-ipfs/ipfs


### PR DESCRIPTION
The Command-line quick start is in two different places for some reason. So /install/command-line-quick-start/ got updates, but how-to/command-line-quick-start/ was missed.