### PR TITLE
Fix Fleek link

### DIFF
--- a/docs/how-to/websites-on-ipfs/link-a-domain.md
+++ b/docs/how-to/websites-on-ipfs/link-a-domain.md
@@ -105,4 +105,4 @@ In a few minutes, you'll be able to go to `Your_Domain.eth/` and view your websi
 
 ## Up next
 
-In the next tutorial in this series, we'll take a look at a tool that will help make this whole process easier: [Fleek](./introducing-fleek)
+In the next tutorial in this series, we'll take a look at a tool that will help make this whole process easier: [Fleek](../introducing-fleek)


### PR DESCRIPTION
The single-dot link resolves to https://docs.ipfs.io/how-to/websites-on-ipfs/link-a-domain/introducing-fleek instead of the desired https://docs.ipfs.io/how-to/websites-on-ipfs/introducing-fleek/