### PR TITLE
Changes Docker image to debug version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
 
   deploy:
     docker:
-      - image: olizilla/ipfs-dns-deploy:latest
+      - image: olizilla/ipfs-dns-deploy:debug
         environment:
           DOMAIN: docs.ipfs.io
           DOMAIN_BETA: docs-beta.ipfs.io


### PR DESCRIPTION
There's an ongoing issue with pushes to `master` not deploying. This PR changes the Docker image to `olizilla/ipfs-dns-deploy:debug` so that the devops folks can get a better look at what's going on.