### PR TITLE
Update install instructions to 0.7.0.

### DIFF
--- a/docs/how-to/command-line-quick-start.md
+++ b/docs/how-to/command-line-quick-start.md
@@ -22,26 +22,26 @@ Installing IPFS is simple, but varies between operating system:
 
 ### Windows
 
-1. Download [`go-ipfs_v0.6.0_windows-386.zip` from GitHub](https://github.com/ipfs/go-ipfs/releases/download/v0.6.0/).
+1. Download [`go-ipfs_v0.7.0_windows-386.zip` from GitHub](https://github.com/ipfs/go-ipfs/releases/download/v0.7.0/).
 
    ```powershell
    cd ~\
-   wget https://github.com/ipfs/go-ipfs/releases/download/v0.6.0/go-ipfs-v0.6.0_windows-386.zip -Outfile go-ipfs-v0.6.0.zip
+   wget https://github.com/ipfs/go-ipfs/releases/download/v0.7.0/go-ipfs-v0.7.0_windows-386.zip -Outfile go-ipfs-v0.7.0.zip
    ```
 
 1. Unzip the file and move it somewhere handy.
 
    ```powershell
-   Expand-Archive -Path go-ipfs-v0.6.0.zip -DestinationPath ~\Apps\go-ipfs_v0.6.0
+   Expand-Archive -Path go-ipfs-v0.7.0.zip -DestinationPath ~\Apps\go-ipfs_v0.7.0
    ```
 
-1. Move into the `go-ipfs_v0.6.0` folder and check that the `ipfs.exe` works:
+1. Move into the `go-ipfs_v0.7.0` folder and check that the `ipfs.exe` works:
 
    ```powershell
-   cd ~\Apps\go-ipfs_v0.6.0\go-ipfs
+   cd ~\Apps\go-ipfs_v0.7.0\go-ipfs
    .\ipfs.exe --version
 
-   > ipfs version 0.6.0
+   > ipfs version 0.7.0
    ```
 
    While you can use IPFS right now, it's better to add `ipfs.exe` to your `PATH.` by using the following steps.
@@ -53,13 +53,13 @@ Installing IPFS is simple, but varies between operating system:
 
    > Path
    > ----
-   > C:\Users\Johnny\Apps\go-ipfs_v0.6.0\go-ipfs
+   > C:\Users\Johnny\Apps\go-ipfs_v0.7.0\go-ipfs
    ```
 
 1. Add the address you just copied to PowerShell's `PATH` by adding it to the end of the `profile.ps1` file stored in `Documents\WindowsPowerShell`:
 
    ```powershell
-   Add-Content C:\Users\Johnny\Documents\WindowsPowerShell\profile.ps1 "[System.Environment]::SetEnvironmentVariable('PATH',`$Env:PATH+';;C:\Users\Johnny\Apps\go-ipfs_v0.6.0\go-ipfs')"
+   Add-Content C:\Users\Johnny\Documents\WindowsPowerShell\profile.ps1 "[System.Environment]::SetEnvironmentVariable('PATH',`$Env:PATH+';;C:\Users\Johnny\Apps\go-ipfs_v0.7.0\go-ipfs')"
    ```
 
 1. Close and reopen your PowerShell window. Test that your IPFS path is set correctly by going to your home folder and asking IPFS for the version:
@@ -68,21 +68,21 @@ Installing IPFS is simple, but varies between operating system:
    cd ~
    ipfs --version
 
-   > ipfs version 0.6.0
+   > ipfs version 0.7.0
    ```
 
 ### macOS
 
-1. Download [`go-ipfs_v0.6.0_darwin-386.tar.gz` from GitHub](https://github.com/ipfs/go-ipfs/releases/tag/v0.6.0).
+1. Download [`go-ipfs_v0.7.0_darwin-386.tar.gz` from GitHub](https://github.com/ipfs/go-ipfs/releases/tag/v0.7.0).
 
    ```bash
-   wget https://github.com/ipfs/go-ipfs/releases/download/v0.6.0/go-ipfs_v0.6.0_darwin-amd64.tar.gz
+   wget https://github.com/ipfs/go-ipfs/releases/download/v0.7.0/go-ipfs_v0.7.0_darwin-amd64.tar.gz
    ```
 
 1. Unzip the file:
 
    ```bash
-   tar -xvzf go-ipfs_v0.6.0_darwin-amd64.tar.gz
+   tar -xvzf go-ipfs_v0.7.0_darwin-amd64.tar.gz
 
    > x go-ipfs/install.sh
    > x go-ipfs/ipfs
@@ -105,21 +105,21 @@ Installing IPFS is simple, but varies between operating system:
    ```bash
    ipfs --version
 
-   > ipfs version 0.6.0
+   > ipfs version 0.7.0
    ```
 
 ### Linux
 
-1. Download [`go-ipfs_v0.6.0_linux-amd64.tar.gz` from GitHub](https://github.com/ipfs/go-ipfs/releases/tag/v0.6.0):
+1. Download [`go-ipfs_v0.7.0_linux-amd64.tar.gz` from GitHub](https://github.com/ipfs/go-ipfs/releases/tag/v0.7.0):
 
    ```bash
-   wget https://github.com/ipfs/go-ipfs/releases/download/v0.6.0/go-ipfs_v0.6.0_linux-amd64.tar.gz
+   wget https://github.com/ipfs/go-ipfs/releases/download/v0.7.0/go-ipfs_v0.7.0_linux-amd64.tar.gz
    ```
 
 1. Unzip the file:
 
    ```bash
-   tar -xvzf go-ipfs_v0.6.0_linux-amd64.tar.gz
+   tar -xvzf go-ipfs_v0.7.0_linux-amd64.tar.gz
 
    > x go-ipfs/install.sh
    > x go-ipfs/ipfs
@@ -143,7 +143,7 @@ Installing IPFS is simple, but varies between operating system:
    ```bash
    ipfs --version
 
-   > ipfs version 0.6.0
+   > ipfs version 0.7.0
    ```
 
 ## Initialize the repository

--- a/docs/install/command-line.md
+++ b/docs/install/command-line.md
@@ -23,7 +23,7 @@ Although we try our best to keep the package manager releases up to date, they s
 
 ## Official distributions
 
-The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help users quickly find the latest version of every IPFS package. As soon as a new release of an IPFS package comes out, it is automatically shown on `dist.ipfs.io`, so you can be sure you're getting the latest software. These steps detail how to download and install Go-IPFS 0.6.0 from `dist.ipfs.io` using the command-line.
+The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help users quickly find the latest version of every IPFS package. As soon as a new release of an IPFS package comes out, it is automatically shown on `dist.ipfs.io`, so you can be sure you're getting the latest software. These steps detail how to download and install Go-IPFS 0.7.0 from `dist.ipfs.io` using the command-line.
 
 | [Windows](#windows)                                                          | [macOS](#macos)                                                        | [Linux](#linux)                                                        |
 | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
@@ -35,22 +35,22 @@ The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help 
 
    ```powershell
    cd ~\
-   wget https://dist.ipfs.io/go-ipfs/v0.6.0/go-ipfs_v0.6.0_windows-amd64.zip -Outfile go-ipfs_v0.6.0.zip
+   wget https://dist.ipfs.io/go-ipfs/v0.7.0/go-ipfs_v0.7.0_windows-amd64.zip -Outfile go-ipfs_v0.7.0.zip
    ```
 
 2. Unzip the file and move it somewhere handy.
 
    ```powershell
-   Expand-Archive -Path go-ipfs_v0.6.0.zip -DestinationPath ~\Apps\go-ipfs_v0.6.0
+   Expand-Archive -Path go-ipfs_v0.7.0.zip -DestinationPath ~\Apps\go-ipfs_v0.7.0
    ```
 
-3. Move into the `go-ipfs_v0.6.0` folder and check that the `ipfs.exe` works:
+3. Move into the `go-ipfs_v0.7.0` folder and check that the `ipfs.exe` works:
 
    ```powershell
-   cd ~\Apps\go-ipfs_v0.6.0\go-ipfs
+   cd ~\Apps\go-ipfs_v0.7.0\go-ipfs
    .\ipfs.exe --version
 
-   > ipfs version 0.6.0
+   > ipfs version 0.7.0
    ```
 
    While you can use IPFS right now, it's better to add `ipfs.exe` to your `PATH.` by using the following steps.
@@ -62,13 +62,13 @@ The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help 
 
    > Path
    > ----
-   > C:\Users\Johnny\Apps\go-ipfs_v0.6.0\go-ipfs
+   > C:\Users\Johnny\Apps\go-ipfs_v0.7.0\go-ipfs
    ```
 
 5. Add the address you just copied to PowerShell's `PATH` by adding it to the end of the `profile.ps1` file stored in `Documents\WindowsPowerShell`:
 
    ```powershell
-   Add-Content C:\Users\Johnny\Documents\WindowsPowerShell\profile.ps1 "[System.Environment]::SetEnvironmentVariable('PATH',`$Env:PATH+';;C:\Users\Johnny\Apps\go-ipfs_v0.6.0\go-ipfs')"
+   Add-Content C:\Users\Johnny\Documents\WindowsPowerShell\profile.ps1 "[System.Environment]::SetEnvironmentVariable('PATH',`$Env:PATH+';;C:\Users\Johnny\Apps\go-ipfs_v0.7.0\go-ipfs')"
    ```
 
 6. Close and reopen your PowerShell window. Test that your IPFS path is set correctly by going to your home folder and asking IPFS for the version:
@@ -77,7 +77,7 @@ The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help 
    cd ~
    ipfs --version
 
-   > ipfs version 0.6.0
+   > ipfs version 0.7.0
    ```
 
 ### macOS
@@ -85,13 +85,13 @@ The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help 
 1. Download the macOS binary from [`dist.ipfs.io`](https://dist.ipfs.io/#go-ipfs).
 
    ```bash
-   wget https://dist.ipfs.io/go-ipfs/v0.6.0/go-ipfs_v0.6.0_darwin-amd64.tar.gz
+   wget https://dist.ipfs.io/go-ipfs/v0.7.0/go-ipfs_v0.7.0_darwin-amd64.tar.gz
    ```
 
 1. Unzip the file:
 
    ```bash
-   tar -xvzf go-ipfs_v0.6.0_darwin-amd64.tar.gz
+   tar -xvzf go-ipfs_v0.7.0_darwin-amd64.tar.gz
 
    > x go-ipfs/install.sh
    > x go-ipfs/ipfs
@@ -114,7 +114,7 @@ The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help 
    ```bash
    ipfs --version
 
-   > ipfs version 0.6.0
+   > ipfs version 0.7.0
    ```
 
 ### Linux
@@ -122,13 +122,13 @@ The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help 
 1. Download the Linux binary from [`dist.ipfs.io`](https://dist.ipfs.io/#go-ipfs).
 
    ```bash
-   wget https://dist.ipfs.io/go-ipfs/v0.6.0/go-ipfs_v0.6.0_linux-amd64.tar.gz
+   wget https://dist.ipfs.io/go-ipfs/v0.7.0/go-ipfs_v0.7.0_linux-amd64.tar.gz
    ```
 
 1. Unzip the file:
 
    ```bash
-   tar -xvzf go-ipfs_v0.6.0_linux-amd64.tar.gz
+   tar -xvzf go-ipfs_v0.7.0_linux-amd64.tar.gz
 
    > x go-ipfs/install.sh
    > x go-ipfs/ipfs
@@ -152,7 +152,7 @@ The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help 
    ```bash
    ipfs --version
 
-   > ipfs version 0.6.0
+   > ipfs version 0.7.0
    ```
 
 ## Compile manually


### PR DESCRIPTION
Pretty much a find and replace of 0.6.0 to 0.7.0 for Go-IPFS installations. Closes #463.