### PR TITLE
remove docs-beta dnslink entry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ jobs:
       - image: olizilla/ipfs-dns-deploy:debug
         environment:
           DOMAIN: docs.ipfs.io
-          DOMAIN_BETA: docs-beta.ipfs.io
           BUILD_DIR: ./docs/.vuepress/dist
           CLUSTER_HOST: /dnsaddr/ipfs-websites.collab.ipfscluster.io
     steps:
@@ -44,10 +43,9 @@ jobs:
             pin_name="$DOMAIN build $CIRCLE_BUILD_NUMBER"
             hash=$(pin-to-cluster.sh "$pin_name" /tmp/workspace/$BUILD_DIR)
             echo "Website added to IPFS: https://ipfs.io/ipfs/$hash"
-            # Update DNSlink for prod and legacy beta domains
+            # Update DNSlink
             if [ "$CIRCLE_BRANCH" == "master" ] ; then
               dnslink-dnsimple -d $DOMAIN -r _dnslink -l /ipfs/$hash
-              dnslink-dnsimple -d $DOMAIN_BETA -r _dnslink -l /ipfs/$hash
             fi
 workflows:
   version: 2


### PR DESCRIPTION
docs-beta is redirected to docs now, do you still need the old dnslink?