### PR TITLE
Fix broken link (404) in cmd line quick start

### DIFF
--- a/docs/how-to/command-line-quick-start.md
+++ b/docs/how-to/command-line-quick-start.md
@@ -14,7 +14,7 @@ Don’t want to use the command line right now? Give the desktop-app implementat
 
 ## Prerequisites
 
-If you have not yet installed Go-IPFS, follow the [install instructions](https://github.com/ipfs/go-ipfs/blob/master/install/command-line.md).
+If you have not yet installed Go-IPFS, follow the [install instructions](https://docs.ipfs.io/install/command-line/).
 
 ## Initialize the repository
 


### PR DESCRIPTION
[This link](https://github.com/ipfs/go-ipfs/blob/master/install/command-line.md) in the command line quick start (which I got to from https://ipfs.io/#install) gives me a 404.

![CleanShot 2020-09-27 at 13 04 16@2x](https://user-images.githubusercontent.com/275734/94374563-0b68b900-00c2-11eb-9faa-2b0949d2d5e0.png)

This PR updates it to one of several options I found. Not sure which is correct, so I could use some guidance.

The options I found are:

* https://docs.ipfs.io/install/command-line/ (in PR)
* https://ipfs.io/ipns/dist.ipfs.io/#go-ipfs
* https://github.com/ipfs/go-ipfs/#install-prebuilt-packages
