### PR TITLE
Add an explicit cd command to copypaste

### DIFF
--- a/docs/install/command-line.md
+++ b/docs/install/command-line.md
@@ -104,6 +104,7 @@ The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help 
 1. Move into the `go-ipfs` folder and run the install script:
 
    ```bash
+   cd go-ipfs
    bash install.sh
 
    > Moved ./ipfs to /usr/local/bin


### PR DESCRIPTION
This matches the equivalent instructions for Linux users later in the file (L145).

I just want to be able to blindly copy instruction and Have It Work(TM).
