### PR TITLE
Fix: Remove hashes from protoschool links (possible cause of mislabeled source in ProtoSchool Countyl stats)

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -372,7 +372,7 @@ module.exports = {
                   '/community/contribute/ways-to-contribute',
                   ['https://discuss.ipfs.io/', 'IPFS forums'],
                   '/community/irc',
-                  ['https://proto.school/#/events', 'ProtoSchool workshops'],
+                  ['https://proto.school/events', 'ProtoSchool workshops'],
                   ['https://www.meetup.com/members/249142444/', 'Meetups'],
                   '/community/social-media',
                   ['https://awesome.ipfs.io', 'Awesome IPFS']

--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -26,7 +26,7 @@ IRC fan? Here are [all our channels](irc). New to IRC? There's getting-started a
 
 ## ProtoSchool workshops
 
-ProtoSchool isn't just home to interactive tutorials on dweb topics — it's also a vibrant community of makers and do-ers around the globe! Community groups worldwide host [ProtoSchool workshops](https://proto.school/#/events) regularly, offering you the opportunity to complete our interactive tutorials with the support of local mentors.
+ProtoSchool isn't just home to interactive tutorials on dweb topics — it's also a vibrant community of makers and do-ers around the globe! Community groups worldwide host [ProtoSchool workshops](https://proto.school/events) regularly, offering you the opportunity to complete our interactive tutorials with the support of local mentors.
 
 ## Meetups
 

--- a/docs/concepts/content-addressing.md
+++ b/docs/concepts/content-addressing.md
@@ -7,7 +7,7 @@ description: Learn about how content addressing works and how content identifier
 # Content addressing and CIDs
 
 ::: tip
-For a deep dive into how Content Identifiers (CIDs) are constructed, take a look at ProtoSchool's tutorial on the [Anatomy of a CID](https://proto.school/#/anatomy-of-a-cid).
+For a deep dive into how Content Identifiers (CIDs) are constructed, take a look at ProtoSchool's tutorial on the [Anatomy of a CID](https://proto.school/anatomy-of-a-cid).
 :::
 
 A _content identifier_, or CID, is a label used to point to material in IPFS. It doesn't indicate _where_ the content is stored, but it forms a kind of address based on the content itself. CIDs are short, regardless of the size of their underlying content.

--- a/docs/concepts/file-systems.md
+++ b/docs/concepts/file-systems.md
@@ -307,7 +307,7 @@ To export or read the file data out of the UnixFS graph, perform an in-order tra
 
 You can find additional resources to familiarize with these file systems at: 
 
-- [Protoschool MFS course](https://proto.school/#/mutable-file-system)
+- [Protoschool MFS course](https://proto.school/mutable-file-system)
 - [Understanding how the InterPlanetary File System deals with Files](https://github.com/ipfs/camp/tree/master/CORE_AND_ELECTIVE_COURSES/CORE_COURSE_A), from IPFS Camp 2019
 - [Jeromy Coffee Talks - Files API](https://www.youtube.com/watch?v=FX_AXNDsZ9k)
 - [UnixFS Specification](https://github.com/ipfs/specs/blob/master/UNIXFS.md)

--- a/docs/reference/js/api.md
+++ b/docs/reference/js/api.md
@@ -7,7 +7,7 @@ description: Developer resources for working in JavaScript with IPFS, the InterP
 # API resources for js-ipfs
 
 ::: callout
-[Explore js-ipfs through interactive coding challenges at ProtoSchool](https://proto.school/#/tutorials?course=ipfs)
+[Explore js-ipfs through interactive coding challenges at ProtoSchool](https://proto.school/tutorials?course=ipfs)
 :::
 
 ## Working with IPFS in JS


### PR DESCRIPTION
This is an optimisation to reduce the number of redirects ProtoSchool users need to go through, but also a possible fix for the lower source traffic in ProtoSchool from docs.ipfs.io, which we will monitor over the following weeks.
After some time we will do another PR to add a main link in the homepage to ProtoSchool like @jessicaschilling suggested.