### PR TITLE
Package manager install options for IPFS Desktop

### DIFF
--- a/docs/install/ipfs-desktop.md
+++ b/docs/install/ipfs-desktop.md
@@ -96,11 +96,13 @@ While these instructions are specific to Ubuntu, they will likely work with most
 
 ## Package Managers
 
-- **Homebrew** - `brew cask install ipfs`
-- **Chocolatey** - `choco install ipfs-desktop`
-- **Scoop** - `scoop install ipfs-desktop`
-- **Snap** - `snap install ipfs-desktop`
-- **AUR** - [`ipfs-desktop` package](https://aur.archlinux.org/packages/ipfs-desktop/) maintained by [@alexhenrie](https://github.com/alexhenrie)
+| Package Manager                                                                                                    | Command                      |
+| ------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| [Homebrew](https://formulae.brew.sh/cask/ipfs/)                                                                    | `brew cask install ipfs`     |
+| [Chocolatey](https://chocolatey.org/packages/ipfs-desktop)                                                         | `choco install ipfs-desktop` |
+| [Scoop](https://github.com/lukesampson/scoop-extras/blob/master/bucket/ipfs-desktop.json)                          | `scoop install ipfs-desktop` |
+| [Snap](https://snapcraft.io/ipfs-desktop)                                                                          | `snap install ipfs-desktop`  |
+| [AUR](https://aur.archlinux.org/packages/ipfs-desktop/) maintained by [@alexhenrie](https://github.com/alexhenrie) | `ipfs-desktop`               |
 
 ## Next steps
 

--- a/docs/install/ipfs-desktop.md
+++ b/docs/install/ipfs-desktop.md
@@ -13,6 +13,8 @@ The installation steps differ between operating systems, so follow the instructi
 | ------------------------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------- |
 | [![Windows icon](./images/ipfs-desktop/windows-icon.png)](#windows) | [![macOS icon](./images/ipfs-desktop/apple-icon.png)](#macos) | [![Ubuntu icon](./images/ipfs-desktop/ubuntu-icon.png)](#ubuntu) |
 
+[Or you can use your favorite package manager and a third-party package maintained by the community](#package-managers)
+
 ## Windows
 
 1. Go to the [IPFS Desktop downloads page](https://github.com/ipfs-shipyard/ipfs-desktop/releases).
@@ -91,6 +93,14 @@ While these instructions are specific to Ubuntu, they will likely work with most
 1. You can now find an IPFS icon in the status bar:
 
    ![IPFS icon shown in the Ubuntu status bar.](./images/ipfs-desktop/install-ubuntu-ipfs-running-status-bar.png)
+
+## Package Managers
+
+- **Homebrew** - `brew cask install ipfs`
+- **Chocolatey** - `choco install ipfs-desktop`
+- **Scoop** - `scoop install ipfs-desktop`
+- **Snap** - `snap install ipfs-desktop`
+- **AUR** - [`ipfs-desktop` package](https://aur.archlinux.org/packages/ipfs-desktop/) maintained by [@alexhenrie](https://github.com/alexhenrie)
 
 ## Next steps
 


### PR DESCRIPTION
Closes #486 

- [x] Add installation instructions for the following package managers:
   - [x] Chocolatey (Windows)
   - [x] Scoop (Windows)
   - [x]  Homebrew (macOS)
   - [x]  Snap (Ubuntu)
   - [x]  Arch User Repository (Arch Linux)

Screenshots:
Added link below OS list:

![image](https://user-images.githubusercontent.com/15967809/96330433-c4436780-1072-11eb-8c3f-6194934c25f4.png)


Added a new sections which have the details from: 
[https://github.com/ipfs-shipyard/ipfs-desktop](https://github.com/ipfs-shipyard/ipfs-desktop)

![image](https://user-images.githubusercontent.com/15967809/96330470-15ebf200-1073-11eb-9d3e-2f253f9173d5.png)
