### PR TITLE
docs(how-to): add "use an existing private key"

### DIFF
--- a/docs/how-to/use-existing-private-key.md
+++ b/docs/how-to/use-existing-private-key.md
@@ -14,7 +14,7 @@ Private keys are handled programmatically through code or through the CLI. Here 
 
 ## CLI (`go-ipfs`)
 
-There's no way of directly initializing an IPFS node using your private keys from IPFS's Go CLI at this moment. To learn more and look for possible workarounds, see the discussion on issue [ipfs/go-ipfs#4240](https://github.com/ipfs/go-ipfs/issues/4240).
+There's no way of directly initializing an IPFS node using your private keys from the Go-IPFS CLI at this time. To learn more and look for possible workarounds, see the discussion on issue [ipfs/go-ipfs#4240](https://github.com/ipfs/go-ipfs/issues/4240).
 
 You can, however, import private keys into the Keystore:
 

--- a/docs/how-to/use-existing-private-key.md
+++ b/docs/how-to/use-existing-private-key.md
@@ -12,7 +12,11 @@ There are two locations in which IPFS stores private keys:
 
 Private keys are handled programmatically through code or through the CLI. Here we will show you how to use your existing private keys using both methods.
 
-## CLI (`go-ipfs`)
+## CLI
+
+Use the CLI to manage your private keys.
+
+### Go-IPFS
 
 There's no way of directly initializing an IPFS node using your private keys from the Go-IPFS CLI at this time. To learn more and look for possible workarounds, see the discussion on issue [ipfs/go-ipfs#4240](https://github.com/ipfs/go-ipfs/issues/4240).
 

--- a/docs/how-to/use-existing-private-key.md
+++ b/docs/how-to/use-existing-private-key.md
@@ -20,7 +20,7 @@ Use the CLI to manage your private keys.
 
 There's no way of directly initializing an IPFS node using your private keys from the Go-IPFS CLI at this time. To learn more and look for possible workarounds, see the discussion on issue [ipfs/go-ipfs#4240](https://github.com/ipfs/go-ipfs/issues/4240).
 
-You can, however, import private keys into the Keystore:
+You can, however, import private keys into the IPFS keystore:
 
 ```sh
 ipfs key import CustomKeyName ./CustomKeyFile
@@ -40,7 +40,7 @@ You can provide the private key inline as a string when initializing:
 jsipfs init --private-key 'my-private-key'
 ```
 
-You can also import private keys into the Keystore:
+You can also import private keys into the IPFS keystore:
 
 ```sh
 jsipfs key import CustomKeyName --passin='your-pem-password' --input=./CustomKeyFile

--- a/docs/how-to/use-existing-private-key.md
+++ b/docs/how-to/use-existing-private-key.md
@@ -10,7 +10,7 @@ There are two locations in which IPFS stores private keys:
 1. In the config file (`~/.ipfs/config`), following the [config specification](https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#identityprivkey) to store the default private key.
 2. In the Keystore (`~/.ipfs/keystore`), following the [fs-repo specification](https://github.com/ipfs/specs/blob/master/REPO_FS.md) to store all other private keys.
 
-Private keys are handled programmatically through code or via the CLI. Here we will show you how to use your existing private keys using both methods.
+Private keys are handled programmatically through code or through the CLI. Here we will show you how to use your existing private keys using both methods.
 
 ## CLI (`go-ipfs`)
 

--- a/docs/how-to/use-existing-private-key.md
+++ b/docs/how-to/use-existing-private-key.md
@@ -7,8 +7,10 @@ description: How to start an IPFS node with a pre-generated private key.
 
 There are two locations in which IPFS stores private keys:
 
-1. In the config file (`~/.ipfs/config`), following the [config specification](https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#identityprivkey) to store the default private key.
-2. In the Keystore (`~/.ipfs/keystore`), following the [fs-repo specification](https://github.com/ipfs/specs/blob/master/REPO_FS.md) to store all other private keys.
+Location | Purpose | Specification
+-------- | --------- | -------------
+Config file (`~/.ipfs/config`) | Holds a single private key; used as the default for initializing the IPFS node, IPNS publishing, etc. | [config#identityprivkey](https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#identityprivkey)
+Keystore (`~/.ipfs/keystore`) | Holds additional private keys the node has access to; can be used for IPNS signing, publishing, etc. | [fs-repo#keystore](https://github.com/ipfs/specs/blob/master/REPO_FS.md#keystore)
 
 Private keys are handled programmatically through code or through the CLI. Here we will show you how to use your existing private keys using both methods.
 

--- a/docs/how-to/use-existing-private-key.md
+++ b/docs/how-to/use-existing-private-key.md
@@ -30,8 +30,7 @@ ipfs key import CustomKeyName ./CustomKeyFile
 > k51qzi5uqu5dlli90qkt7xcnnjsd6jkn5rbdg7scuv6leozp1ecokewk5rzbeh
 ```
 
-The content of the file holding the private key you want to import into the Keystore needs to be in the correct format to be valid.
-The format of Keystore files is outlined in the [fs-repo](https://github.com/ipfs/specs/blob/master/REPO_FS.md#keystore) specification.
+The content of the file holding the private key you want to import into the IPFS keystore needs to be in the correct format to be valid. The format of keystore files is outlined in the [fs-repo](https://github.com/ipfs/specs/blob/master/REPO_FS.md#keystore) specification.
 
 
 ### JS-IPFS

--- a/docs/how-to/use-existing-private-key.md
+++ b/docs/how-to/use-existing-private-key.md
@@ -37,7 +37,7 @@ For more information on the CLI commands, you can check the help option for the 
 ipfs COMMAND --help
 ```
 
-## CLI - JS (`js-ipfs`)
+### JS-IPFS
 
 You can provide the private key inline as a string when initializing (see `--help` for info on valid formats):
 

--- a/docs/how-to/use-existing-private-key.md
+++ b/docs/how-to/use-existing-private-key.md
@@ -31,15 +31,10 @@ ipfs key import CustomKeyName ./CustomKeyFile
 The content of the file holding the private key you want to import into the Keystore needs to be in the correct format to be valid.
 The format of Keystore files is outlined in the [fs-repo](https://github.com/ipfs/specs/blob/master/REPO_FS.md#keystore) specification.
 
-For more information on the CLI commands, you can check the help option for the specific command:
-
-```sh
-ipfs COMMAND --help
-```
 
 ### JS-IPFS
 
-You can provide the private key inline as a string when initializing (see `--help` for info on valid formats):
+You can provide the private key inline as a string when initializing:
 
 ```sh
 jsipfs init --private-key 'my-private-key'
@@ -53,19 +48,13 @@ jsipfs key import CustomKeyName --passin='your-pem-password' --input=./CustomKey
 > imported QmcasS8sQuasoFb2MDXbmBDwatWdhbkXrmx7131Rban9GG CustomKeyName
 ```
 
-For more information on the CLI commands, you can check the help option for the specific command:
-
-```sh
-jsipfs COMMAND --help
-```
-
 ## Programmatically
 
 Manage your private keys programmatically.
 
 ### JavaScript
 
-Using pre-generated private keys with JavaScript is pretty straight-forward:
+Using pre-generated private keys with JavaScript is straight-forward:
 
 1. Import the IPFS module.
 2. Create the node, passing the desired private key in the [correct format](https://github.com/ipfs/js-ipfs/blob/master/docs/MODULE.md#optionsinit) to the `IPFS.create` function parameter:
@@ -77,13 +66,13 @@ const myExistingPrivateKey = 'my-private-key'
 const ipfs = await IPFS.create({ privateKey: myExistingPrivateKey })
 ```
 
-## Go
+### Go
 
 Unfortunately, there's no clear way of initializing an IPFS node using your private keys from IPFS's Go Library at this moment.
 
 ## Troubleshooting
 
-- Key not changing
+### Key not changing
   - If you already have an initialized repo (i.e., `~/.jsipfs` is not empty), the existing key from the config file (`~/.jsipfs/config`) will be used instead of the provided one ([ipfs/js-ipfs#2261](https://github.com/ipfs/js-ipfs/issues/2261#issuecomment-637449985)).
 
 ## Use cases
@@ -93,10 +82,6 @@ Unfortunately, there's no clear way of initializing an IPFS node using your priv
 - Use in CI/CD pipelines.
 - Rotate the IPFS identity.
 - Use keys created from a third-party.
-
-## Security
-
-You'll have to take care of the handling of keys and their security. Remember that private keys are your identity and the only way of seeing encrypted content, publishing as you, among other actions. It's a protection layer between the user and the raw data.
 
 ## Learn more
 

--- a/docs/how-to/use-existing-private-key.md
+++ b/docs/how-to/use-existing-private-key.md
@@ -1,0 +1,95 @@
+---
+title: Use an existing private key
+description: How to start an IPFS node with a pre-generated private key.
+---
+
+# Use an existing private key
+
+There are two locations in which IPFS stores private keys:
+
+1. In the config file (`~/.ipfs/config`), following the [config specification](https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#identityprivkey) to store the default private key.
+2. In the Keystore (`~/.ipfs/keystore`), following the [fs-repo specification](https://github.com/ipfs/specs/blob/master/REPO_FS.md) to store all other private keys.
+
+Private keys are handled programmatically through code or via the CLI. Here we will show you how to use your existing private keys using both methods.
+
+## CLI (`go-ipfs`)
+
+There's no way of directly initializing an IPFS node using your private keys from IPFS's Go CLI at this moment. To learn more and look for possible workarounds, see the discussion on issue [ipfs/go-ipfs#4240](https://github.com/ipfs/go-ipfs/issues/4240).
+
+You can, however, import private keys into the Keystore:
+
+```sh
+ipfs key import CustomKeyName ./CustomKeyFile
+
+> k51qzi5uqu5dlli90qkt7xcnnjsd6jkn5rbdg7scuv6leozp1ecokewk5rzbeh
+```
+
+The content of the file holding the private key you want to import into the Keystore needs to be in the correct format to be valid.
+The format of Keystore files is outlined in the [fs-repo](https://github.com/ipfs/specs/blob/master/REPO_FS.md#keystore) specification.
+
+For more information on the CLI commands, you can check the help option for the specific command:
+
+```sh
+ipfs COMMAND --help
+```
+
+## CLI - JS (`js-ipfs`)
+
+You can provide the private key inline as a string when initializing (see `--help` for info on valid formats):
+
+```sh
+jsipfs init --private-key 'my-private-key'
+```
+
+You can also import private keys into the Keystore:
+
+```sh
+jsipfs key import CustomKeyName --passin='your-pem-password' --input=./CustomKeyFile
+
+> imported QmcasS8sQuasoFb2MDXbmBDwatWdhbkXrmx7131Rban9GG CustomKeyName
+```
+
+For more information on the CLI commands, you can check the help option for the specific command:
+
+```sh
+jsipfs COMMAND --help
+```
+
+## JavaScript
+
+Using pre-generated private keys with JavaScript is pretty straight-forward:
+
+1. Import the IPFS module.
+2. Create the node, passing the desired private key in the [correct format](https://github.com/ipfs/js-ipfs/blob/master/docs/MODULE.md#optionsinit) to the `IPFS.create` function parameter:
+
+```javascript
+import IPFS from 'ipfs'
+
+const myExistingPrivateKey = 'my-private-key'
+const ipfs = await IPFS.create({ privateKey: myExistingPrivateKey })
+```
+
+## Go
+
+Unfortunately, there's no clear way of initializing an IPFS node using your private keys from IPFS's Go Library at this moment.
+
+## Troubleshooting
+
+- Key not changing
+  - If you already have an initialized repo (i.e., `~/.jsipfs` is not empty), the existing key from the config file (`~/.jsipfs/config`) will be used instead of the provided one ([ipfs/js-ipfs#2261](https://github.com/ipfs/js-ipfs/issues/2261#issuecomment-637449985)).
+
+## Use cases
+
+- Use the keys for IPNS publishing.
+- Temporary and disposable keys.
+- Use in CI/CD pipelines.
+- Rotate the IPFS identity.
+- Use keys created from a third-party.
+
+## Security
+
+You'll have to take care of the handling of keys and their security. Remember that private keys are your identity and the only way of seeing encrypted content, publishing as you, among other actions. It's a protection layer between the user and the raw data.
+
+## Learn more
+
+We highly recommend you check the existing GitHub issues for the library you're interested in using. They can be very insightful and help you through the learning process.

--- a/docs/how-to/use-existing-private-key.md
+++ b/docs/how-to/use-existing-private-key.md
@@ -59,7 +59,11 @@ For more information on the CLI commands, you can check the help option for the 
 jsipfs COMMAND --help
 ```
 
-## JavaScript
+## Programmatically
+
+Manage your private keys programmatically.
+
+### JavaScript
 
 Using pre-generated private keys with JavaScript is pretty straight-forward:
 


### PR DESCRIPTION
Add "use an existing private key" to the how-to section.

Fixes #386