### PR TITLE
Fix broken link

### DIFF
--- a/docs/concepts/privacy.md
+++ b/docs/concepts/privacy.md
@@ -64,7 +64,7 @@ If your privacy concerns are less about the potential for monitoring and more ab
 
 There's one caveat to keep in mind here: While today's encryption might seem bulletproof _today_, it's not guaranteed that it won't be broken at some point in the future. Future breakthroughs in computing might allow going back and decrypting older content that's been put on a public network such as IPFS. If you want to guard against this potential attack vector, using IPFS hybrid-private networks — in which nodes sit behind connection gates that check request ACLs before giving a node a request — is a potential design direction. (For more details, [this article from Pinata](https://medium.com/pinata/dedicated-ipfs-networks-c692d53f938d) may be helpful.)
 
-If you're curious about implementing encryption with IPFS on a large scale, you may enjoy reading [this case study on Fleek, a fast-growing IPFS file hosting and delivery service](concepts/case-study-fleek/).
+If you're curious about implementing encryption with IPFS on a large scale, you may enjoy reading [this case study on Fleek, a fast-growing IPFS file hosting and delivery service](/concepts/case-study-fleek/).
 
 ### Creating a private network
 


### PR DESCRIPTION
The link to the Fleek case study is broken. If you go on [the docs](https://docs.ipfs.io/concepts/privacy/#encrypting-content-transported-via-ipfs) and click on the link `this case study on Fleek, a fast-growing IPFS file hosting and delivery service`, you will get a 404 error. This fixes it.

![tmp_ipfs_docs](https://user-images.githubusercontent.com/51865119/103467808-2a2abb80-4d53-11eb-9427-9addd497685d.png)
