### PR TITLE
Fixed codeblock identation

### DIFF
--- a/docs/concepts/ipns.md
+++ b/docs/concepts/ipns.md
@@ -91,11 +91,11 @@ When looking up an IPNS address, use the `/ipns/` prefix:
 
 You can view the `Qm` hash of the file associated with your `k5` key by using `name resolve`:
 
-    ```bash
-    ipfs name resolve
+```bash
+ipfs name resolve
 
-    > /ipfs/QmUVTKsrYJpaxUT7dr9FpKq6AoKHhEM7eG1ZHGL56haKLG
-    ```
+> /ipfs/QmUVTKsrYJpaxUT7dr9FpKq6AoKHhEM7eG1ZHGL56haKLG
+```
 
 To use a different `k5` key, first create one using `key gen test`, and use the `--key` flag when calling `name publish`:
 


### PR DESCRIPTION
## Description
There is a code block [here](https://docs.ipfs.io/concepts/ipns/#example-ipns-setup-with-cli) bad indented.

This is how it currently looks like:

![image](https://user-images.githubusercontent.com/38158676/104104913-1b8c5900-52ab-11eb-8df1-372a2859bea0.png)

This is how it looks after the fix (I took the screenshot from GitHub):

![image](https://user-images.githubusercontent.com/38158676/104104995-9a819180-52ab-11eb-8b9a-6f846255e593.png)


## Fix
I simply fixed the indentation