### PR TITLE
Use promise instead of a callback as argument in ipfs.name.publish example

### DIFF
--- a/docs/concepts/ipns.md
+++ b/docs/concepts/ipns.md
@@ -119,7 +119,7 @@ Here's where the Name API comes in handy. With it, you can create a single, stab
 // The address of your files.
 const addr = '/ipfs/QmbezGequPwcsWo8UL4wDF6a8hYwM1hmbzYv2mnKkEWaUp'
 
-ipfs.name.publish(addr, function (err, res) {
+ipfs.name.publish(addr).then(function (res) {
   // You now receive a res which contains two fields:
   //   - name: the name under which the content was published.
   //   - value: the "real" address to which Name points.


### PR DESCRIPTION
## Description
In October 21th the method `ipfs.name.publish` removed the ability to pass a function as callback. Currently, you can only use the promise-based callback. This PR updates the docs, so the example uses a promised-based callback.

Link to the docs page: https://docs.ipfs.io/concepts/ipns/#example-ipns-setup-with-js-sdk-api

Old (callback as argument):

![image](https://user-images.githubusercontent.com/38158676/104105956-48903a00-52b2-11eb-84ab-e8b9d0adbdd4.png)

## Context
This is the commit that removed the function as argument callback: https://github.com/ipfs/js-ipfs/commit/bbcaf34111251b142273a5675f4754ff68bd9fa0#diff-9899aad8c28df56d9808f76d9f98c23a49ec9cd4eadeeb888c1e1098ac17b245

![image](https://user-images.githubusercontent.com/38158676/104106068-22b76500-52b3-11eb-8b4f-7ce08cc98751.png)

## Result

My fix (promised-based callback):

![image](https://user-images.githubusercontent.com/38158676/104105965-5c3ba080-52b2-11eb-8113-13b8beeff5eb.png)


