### PR TITLE
Only pin master builds to collaborative cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
             
             hash=$(pin-to-cluster.sh "$pin_name" /tmp/workspace/$BUILD_DIR)
             echo "Website added to IPFS: https://ipfs.io/ipfs/$hash"
-            # Update DNSlink for prod or dev domain
+            # Update DNSlink for prod
             if [ "$CIRCLE_BRANCH" == "main" ] ; then
               dnslink-dnsimple -d $DOMAIN -r _dnslink -l /ipfs/$hash
               export CLUSTER_HOST=/dnsaddr/ipfs-websites.collab.ipfscluster.io

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             pin_name="$DOMAIN build $CIRCLE_BUILD_NUMBER"
             hash=$(pin-to-cluster.sh "$pin_name" /tmp/workspace/$BUILD_DIR)
             echo "Website added to IPFS: https://ipfs.io/ipfs/$hash"
-            # Update DNSlink for prod
+            # Update DNSlink
             if [ "$CIRCLE_BRANCH" == "main" ] ; then
               dnslink-dnsimple -d $DOMAIN -r _dnslink -l /ipfs/$hash
               export CLUSTER_HOST=/dnsaddr/ipfs-websites.collab.ipfscluster.io

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
             hash=$(pin-to-cluster.sh "$pin_name" /tmp/workspace/$BUILD_DIR)
             echo "Website added to IPFS: https://ipfs.io/ipfs/$hash"
             # Update DNSlink for prod or dev domain
-            if [ "$CIRCLE_BRANCH" == "master" ] ; then
+            if [ "$CIRCLE_BRANCH" == "main" ] ; then
               dnslink-dnsimple -d $DOMAIN -r _dnslink -l /ipfs/$hash
               export CLUSTER_HOST=/dnsaddr/ipfs-websites.collab.ipfscluster.io
               pin-to-cluster.sh "$DOMAIN" /tmp/workspace/$BUILD_DIR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ jobs:
         environment:
           DOMAIN: docs.ipfs.io
           BUILD_DIR: ./docs/.vuepress/dist
-          CLUSTER_HOST: /dnsaddr/ipfs-websites.collab.ipfscluster.io
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -41,7 +40,6 @@ jobs:
           name: Deploy website to IPFS
           command: |
             pin_name="$DOMAIN build $CIRCLE_BUILD_NUMBER"
-            
             hash=$(pin-to-cluster.sh "$pin_name" /tmp/workspace/$BUILD_DIR)
             echo "Website added to IPFS: https://ipfs.io/ipfs/$hash"
             # Update DNSlink for prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,15 @@ jobs:
           name: Deploy website to IPFS
           command: |
             pin_name="$DOMAIN build $CIRCLE_BUILD_NUMBER"
+            
             hash=$(pin-to-cluster.sh "$pin_name" /tmp/workspace/$BUILD_DIR)
             echo "Website added to IPFS: https://ipfs.io/ipfs/$hash"
-            # Update DNSlink
-            if [ "$CIRCLE_BRANCH" == "main" ] ; then
+            # Update DNSlink for prod or dev domain
+            if [ "$CIRCLE_BRANCH" == "master" ] ; then
               dnslink-dnsimple -d $DOMAIN -r _dnslink -l /ipfs/$hash
-            fi
+              export CLUSTER_HOST=/dnsaddr/ipfs-websites.collab.ipfscluster.io
+              pin-to-cluster.sh "$DOMAIN" /tmp/workspace/$BUILD_DIR
+              echo "Website added to collaborative cluster"
 workflows:
   version: 2
   build-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
               export CLUSTER_HOST=/dnsaddr/ipfs-websites.collab.ipfscluster.io
               pin-to-cluster.sh "$DOMAIN" /tmp/workspace/$BUILD_DIR
               echo "Website added to collaborative cluster"
+            fi
 workflows:
   version: 2
   build-deploy:


### PR DESCRIPTION
Every website build is sent to the collaborative cluster, but it should rather put those in the legacy cluster and only add the master builds into the collaborative one.