### PR TITLE
Add a note about Snap confinement

### DIFF
--- a/docs/install/command-line.md
+++ b/docs/install/command-line.md
@@ -22,7 +22,7 @@ Most operating systems have a package manager, although they may not come pre-in
 Although we try our best to keep the package manager releases up to date, they sometimes lag behind the Go-IPFS GitHub releases page by a few days. If you'd like to install a release the very same day it comes out, use the [official distributions](#official-distributions) from [dist.ipfs.io](https://dist.ipfs.io).
 
 :::warning
-On Ubuntu, the IPFS Snap uses [strict confinement](https://snapcraft.io/docs/snap-confinement) by default and might affect usability of IPFS. Consider specifying the `--classic` option when installing.
+On Ubuntu, the IPFS Snap uses [strict confinement](https://snapcraft.io/docs/snap-confinement) by default.  This includes some restrictions, such as not allowing `ipfs` to access files outside of `/home`. If this affects usability for you, consider [connecting](https://snapcraft.io/docs/interface-management) the [removable-media interface](https://snapcraft.io/docs/removable-media-interface) for `ipfs` snap, or specifying the `--classic` option when installing.
 :::
 
 ## Official distributions

--- a/docs/install/command-line.md
+++ b/docs/install/command-line.md
@@ -21,6 +21,8 @@ Most operating systems have a package manager, although they may not come pre-in
 
 Although we try our best to keep the package manager releases up to date, they sometimes lag behind the Go-IPFS GitHub releases page by a few days. If you'd like to install a release the very same day it comes out, use the [official distributions](#official-distributions) from [dist.ipfs.io](https://dist.ipfs.io).
 
+Note on Ubuntu Snap install: The IPFS Snap uses "strict" [confinement](https://snapcraft.io/docs/snap-confinement) by default, which may affect usability on the command line.  Consider specifying the `--classic` option when installing.
+
 ## Official distributions
 
 The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help users quickly find the latest version of every IPFS package. As soon as a new release of an IPFS package comes out, it is automatically shown on `dist.ipfs.io`, so you can be sure you're getting the latest software. These steps detail how to download and install Go-IPFS 0.7.0 from `dist.ipfs.io` using the command-line.

--- a/docs/install/command-line.md
+++ b/docs/install/command-line.md
@@ -13,11 +13,11 @@ There are several different ways to install IPFS using the command-line. The eas
 
 Most operating systems have a package manager, although they may not come pre-installed. Both Windows and macOS have open-source package managers that must be installed by the user. Ubuntu comes with the Snap package manager pre-installed. Package managers download packages, install applications, and keep everything up-to-date. They're the easiest way to install IPFS from the command-line.
 
-| Operating system | Package manager                                    | Install command      |
-| ---------------- | -------------------------------------------------- | -------------------- |
-| Windows          | [Chocolatey](https://chocolatey.org/packages/ipfs) | `choco install ipfs` |
-| macOS            | [Homebrew](https://formulae.brew.sh/formula/ipfs)  | `brew install ipfs`  |
-| Ubuntu           | [Snap](https://snapcraft.io/ipfs)                  | `snap install ipfs --classic` |
+| Operating system | Package manager                                    | Install command      | Notes |
+| ---------------- | -------------------------------------------------- | -------------------- | ----- |
+| Windows          | [Chocolatey](https://chocolatey.org/packages/ipfs) | `choco install ipfs` | |
+| macOS            | [Homebrew](https://formulae.brew.sh/formula/ipfs)  | `brew install ipfs`  | |
+| Ubuntu           | [Snap](https://snapcraft.io/ipfs)                  | `snap install ipfs` | The IPFS Snap uses [strict confinement](https://snapcraft.io/docs/snap-confinement) by default which may affect usability of IPFS.  Consider specifying the `--classic` option when installing. |
 
 Although we try our best to keep the package manager releases up to date, they sometimes lag behind the Go-IPFS GitHub releases page by a few days. If you'd like to install a release the very same day it comes out, use the [official distributions](#official-distributions) from [dist.ipfs.io](https://dist.ipfs.io).
 

--- a/docs/install/command-line.md
+++ b/docs/install/command-line.md
@@ -19,9 +19,11 @@ Most operating systems have a package manager, although they may not come pre-in
 | macOS            | [Homebrew](https://formulae.brew.sh/formula/ipfs)  | `brew install ipfs`  |
 | Ubuntu           | [Snap](https://snapcraft.io/ipfs)                  | `snap install ipfs`  |
 
-Although we try our best to keep the package manager releases up to date, they sometimes lag behind the Go-IPFS GitHub releases page by a few days. If you'd like to install a release the very same day it comes out, use the [official distributions](#official-distributions) from [dist.ipfs.io](https://dist.ipfs.io).
+:::warning
+The IPFS Snap uses _strict_ [confinement](https://snapcraft.io/docs/snap-confinement) by default, which may affect usability through the command-line.  Consider specifying the `--classic` option when installing.
+:::
 
-Note on Ubuntu Snap install: The IPFS Snap uses "strict" [confinement](https://snapcraft.io/docs/snap-confinement) by default, which may affect usability on the command line.  Consider specifying the `--classic` option when installing.
+Although we try our best to keep the package manager releases up to date, they sometimes lag behind the Go-IPFS GitHub releases page by a few days. If you'd like to install a release the very same day it comes out, use the [official distributions](#official-distributions) from [dist.ipfs.io](https://dist.ipfs.io).
 
 ## Official distributions
 

--- a/docs/install/command-line.md
+++ b/docs/install/command-line.md
@@ -17,11 +17,7 @@ Most operating systems have a package manager, although they may not come pre-in
 | ---------------- | -------------------------------------------------- | -------------------- |
 | Windows          | [Chocolatey](https://chocolatey.org/packages/ipfs) | `choco install ipfs` |
 | macOS            | [Homebrew](https://formulae.brew.sh/formula/ipfs)  | `brew install ipfs`  |
-| Ubuntu           | [Snap](https://snapcraft.io/ipfs)                  | `snap install ipfs`  |
-
-:::warning
-The IPFS Snap uses _strict_ [confinement](https://snapcraft.io/docs/snap-confinement) by default, which may affect usability through the command-line.  Consider specifying the `--classic` option when installing.
-:::
+| Ubuntu           | [Snap](https://snapcraft.io/ipfs)                  | `snap install ipfs --classic` |
 
 Although we try our best to keep the package manager releases up to date, they sometimes lag behind the Go-IPFS GitHub releases page by a few days. If you'd like to install a release the very same day it comes out, use the [official distributions](#official-distributions) from [dist.ipfs.io](https://dist.ipfs.io).
 

--- a/docs/install/command-line.md
+++ b/docs/install/command-line.md
@@ -13,13 +13,17 @@ There are several different ways to install IPFS using the command-line. The eas
 
 Most operating systems have a package manager, although they may not come pre-installed. Both Windows and macOS have open-source package managers that must be installed by the user. Ubuntu comes with the Snap package manager pre-installed. Package managers download packages, install applications, and keep everything up-to-date. They're the easiest way to install IPFS from the command-line.
 
-| Operating system | Package manager                                    | Install command      | Notes |
-| ---------------- | -------------------------------------------------- | -------------------- | ----- |
-| Windows          | [Chocolatey](https://chocolatey.org/packages/ipfs) | `choco install ipfs` | |
-| macOS            | [Homebrew](https://formulae.brew.sh/formula/ipfs)  | `brew install ipfs`  | |
-| Ubuntu           | [Snap](https://snapcraft.io/ipfs)                  | `snap install ipfs` | The IPFS Snap uses [strict confinement](https://snapcraft.io/docs/snap-confinement) by default which may affect usability of IPFS.  Consider specifying the `--classic` option when installing. |
+| Operating system | Package manager                                    | Install command      |
+| ---------------- | -------------------------------------------------- | -------------------- |
+| Windows          | [Chocolatey](https://chocolatey.org/packages/ipfs) | `choco install ipfs` |
+| macOS            | [Homebrew](https://formulae.brew.sh/formula/ipfs)  | `brew install ipfs`  |
+| Ubuntu           | [Snap](https://snapcraft.io/ipfs)                  | `snap install ipfs`  |
 
 Although we try our best to keep the package manager releases up to date, they sometimes lag behind the Go-IPFS GitHub releases page by a few days. If you'd like to install a release the very same day it comes out, use the [official distributions](#official-distributions) from [dist.ipfs.io](https://dist.ipfs.io).
+
+:::warning
+On Ubuntu, the IPFS Snap uses [strict confinement](https://snapcraft.io/docs/snap-confinement) by default and might affect usability of IPFS. Consider specifying the `--classic` option when installing.
+:::
 
 ## Official distributions
 


### PR DESCRIPTION
Users who want to know how to install IPFS may not be aware of Snap's [confinement](https://snapcraft.io/docs/snap-confinement) behavior.  So, I thought it useful to add a note someplace where they might see it before they install the Ubuntu Snap package.

Hopefully, this can prevent issues like this one: https://github.com/ipfs/go-ipfs/issues/7872