### PR TITLE
Changed docsBranch value to main

### DIFF
--- a/docs/.vuepress/theme/components/EditOrIssue.vue
+++ b/docs/.vuepress/theme/components/EditOrIssue.vue
@@ -43,7 +43,7 @@ export default {
       const {
         repo,
         docsDir = '',
-        docsBranch = 'master',
+        docsBranch = 'main',
         docsRepo = repo
       } = this.$site.themeConfig
 


### PR DESCRIPTION
`Edit this page` href currently opens url with `master` branch but is has been changed to `main`

![image](https://user-images.githubusercontent.com/35376824/106094499-c009fa00-60f7-11eb-9f4e-b773aeee2ddc.png)
