### PR TITLE
fix: change master to main for site config

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -43,7 +43,7 @@ module.exports = {
     domain: DEPLOY_DOMAIN,
     docsRepo: 'ipfs/ipfs-docs',
     docsDir: 'docs',
-    docsBranch: 'master',
+    docsBranch: 'main',
     feedbackWidget: {
       docsRepoIssue: 'ipfs/ipfs-docs'
     },


### PR DESCRIPTION
fixes the incorrect master repo links as reported in #616.

closes: #616