### PR TITLE
docs: make it clear that _dnslink should be used

### DIFF
--- a/docs/concepts/dnslink.md
+++ b/docs/concepts/dnslink.md
@@ -11,25 +11,26 @@ DNSLink uses [DNS TXT](https://en.wikipedia.org/wiki/TXT_record) records to map 
 A DNSLink address looks like an [IPNS](/guides/concepts/ipns) address, but it uses a domain name in place of a hashed public key:
 
 ```
-/ipns/myexampledomain.org
+/ipns/example.org
 ```
 
 Just like normal IPFS addresses, they can include links to other files — or other types of resources that IPFS supports, like directories and symlinks:
 
 ```
-/ipns/myexampledomain.org/media/
+/ipns/example.org/media/
 ```
 
 ## Publish Using a Subdomain
 
-While you can publish the TXT record to the exact domain if you so wish, it can be more advantageous to publish DNSLink records using a special subdomain called `_dnslink`. This enables you to improve the security of an automated setup or delegate control over your DNSLink records to a third party without giving away full control over the original DNS zone.
+Publish the TXT record using a special subdomain called `_dnslink`. 
 
-For example, [`docs.ipfs.io`](https://docs.ipfs.io) does not have a TXT record, but the page still loads
-because a TXT record exists for `_dnslink.docs.ipfs.io`. If you look up the DNS records for `_dnslink.docs.ipfs.io`, you'll see its DNSLink entry:
+This not only makes DNSLink lookup more efficient by only returning relevant TXT records, but enables you to improve the security of an automated setup or delegate control over your DNSLink records to a third party without giving away full control over the original DNS zone.
 
-```sh
+For example, [`docs.ipfs.io`](https://docs.ipfs.io) loads because a TXT record exists for `_dnslink.docs.ipfs.io`. If you look up the DNS records for `_dnslink.docs.ipfs.io`, you'll see its DNSLink entry:
+
+```console
 $ dig +noall +answer TXT \_dnslink.docs.ipfs.io
-\_dnslink.docs.ipfs.io. 34 IN TXT "dnslink=/ipfs/QmVMxjouRQCA2QykL5Rc77DvjfaX6m8NL6RyHXRTaZ9iya"
+\_dnslink.docs.ipfs.io. 30 IN TXT "dnslink=/ipfs/bafybeieenxnjdjm7vbr5zdwemaun4sw4iy7h4imlvvl433q6gzjg6awdpq"
 
 ```
 

--- a/docs/concepts/dnslink.md
+++ b/docs/concepts/dnslink.md
@@ -1,12 +1,12 @@
 ---
 title: DNSLink
 legacyUrl: https://docs.ipfs.io/guides/concepts/dnslink/
-description: Learn how DNSLink works in conjunction with IPFS to map DNS names to IPFS content.
+description: Learn how to map IPFS content to DNS names using DNSLink.
 ---
 
 # DNSLink
 
-DNSLink uses [DNS TXT](https://en.wikipedia.org/wiki/TXT_record) records to map a DNS name (like `ipfs.io`) to an IPFS address. Because you can edit your DNS records, you can use them to always point to the latest version of an object in IPFS (remember that an IPFS object's address changes if you modify the object). Since DNSLink uses DNS records, you can assign names/paths/(sub)domains/whatever that are easy to type, read, and remember.
+DNSLink uses [DNS `TXT` records](https://en.wikipedia.org/wiki/TXT_record) to map a DNS name, like ipfs.io`, to an IPFS address. Because you can edit your DNS records, you can use them to always point to the latest version of an object in IPFS. Since DNSLink uses DNS records, you can assign names, paths, and sub-domains that are easy to type, read, and remember.
 
 A DNSLink address looks like an [IPNS](/guides/concepts/ipns) address, but it uses a DNS name in place of a hashed public key:
 
@@ -20,21 +20,21 @@ Just like normal IPFS addresses, they can include links to other files — or ot
 /ipns/example.org/media/
 ```
 
-## Publish Content Path in DNSLink Record
+## Publish content path
 
-Publish the mapping as DNS TXT record using your hostname prefixed with `_dnslink`. 
+Publish the mapping as DNS `TXT` record using your hostname prefixed with `_dnslink`. 
 
-This not only makes DNSLink lookup more efficient by only returning relevant TXT records, but enables you to improve the security of an automated setup or delegate control over your DNSLink records to a third party without giving away full control over the original DNS zone.
+This not only makes DNSLink lookup more efficient by only returning relevant `TXT` records but enables you to improve the security of an automated setup or delegate control over your DNSLink records to a third party without giving away complete control over the original DNS zone.
 
-For example, [`docs.ipfs.io`](https://docs.ipfs.io) loads because a TXT record exists for `_dnslink.docs.ipfs.io`. If you look up the DNS records for `_dnslink.docs.ipfs.io`, you'll see its DNSLink entry:
+For example, [`docs.ipfs.io`](https://docs.ipfs.io) loads because a `TXT` record exists for `_dnslink.docs.ipfs.io`. If you look up the DNS records for `_dnslink.docs.ipfs.io`, you'll see the DNSLink entry:
 
 ```console
-$ dig +noall +answer TXT \_dnslink.docs.ipfs.io
-\_dnslink.docs.ipfs.io. 30 IN TXT "dnslink=/ipfs/bafybeieenxnjdjm7vbr5zdwemaun4sw4iy7h4imlvvl433q6gzjg6awdpq"
+dig +noall +answer TXT \_dnslink.docs.ipfs.io
+> \_dnslink.docs.ipfs.io. 30 IN TXT "dnslink=/ipfs/bafybeieenxnjdjm7vbr5zdwemaun4sw4iy7h4imlvvl433q6gzjg6awdpq"
 
 ```
 
-## Resolve DNSLink Name
+## Resolve DNSLink name
 
 When an IPFS client or node attempts to resolve an address, it looks for a `TXT` record that is prefixed with `dnslink=`. The rest can be an `/ipfs/` link (as in the example below), or `/ipns/`, or even a link to another DNSLink.
 

--- a/docs/concepts/dnslink.md
+++ b/docs/concepts/dnslink.md
@@ -1,14 +1,14 @@
 ---
 title: DNSLink
 legacyUrl: https://docs.ipfs.io/guides/concepts/dnslink/
-description: Learn how DNSLink works in conjunction with IPFS to map domain names to IPFS content.
+description: Learn how DNSLink works in conjunction with IPFS to map DNS names to IPFS content.
 ---
 
 # DNSLink
 
-DNSLink uses [DNS TXT](https://en.wikipedia.org/wiki/TXT_record) records to map a domain name (like `ipfs.io`) to an IPFS address. Because you can edit your DNS records, you can use them to always point to the latest version of an object in IPFS (remember that an IPFS object's address changes if you modify the object). Since DNSLink uses DNS records, you can assign names/paths/(sub)domains/whatever that are easy to type, read, and remember.
+DNSLink uses [DNS TXT](https://en.wikipedia.org/wiki/TXT_record) records to map a DNS name (like `ipfs.io`) to an IPFS address. Because you can edit your DNS records, you can use them to always point to the latest version of an object in IPFS (remember that an IPFS object's address changes if you modify the object). Since DNSLink uses DNS records, you can assign names/paths/(sub)domains/whatever that are easy to type, read, and remember.
 
-A DNSLink address looks like an [IPNS](/guides/concepts/ipns) address, but it uses a domain name in place of a hashed public key:
+A DNSLink address looks like an [IPNS](/guides/concepts/ipns) address, but it uses a DNS name in place of a hashed public key:
 
 ```
 /ipns/example.org
@@ -20,9 +20,9 @@ Just like normal IPFS addresses, they can include links to other files — or ot
 /ipns/example.org/media/
 ```
 
-## Publish Using a Subdomain
+## Publish Content Path in DNSLink Record
 
-Publish the TXT record using a special subdomain called `_dnslink`. 
+Publish the mapping as DNS TXT record using your hostname prefixed with `_dnslink`. 
 
 This not only makes DNSLink lookup more efficient by only returning relevant TXT records, but enables you to improve the security of an automated setup or delegate control over your DNSLink records to a third party without giving away full control over the original DNS zone.
 
@@ -34,7 +34,7 @@ $ dig +noall +answer TXT \_dnslink.docs.ipfs.io
 
 ```
 
-## Resolve Using DNSLink
+## Resolve DNSLink Name
 
 When an IPFS client or node attempts to resolve an address, it looks for a `TXT` record that is prefixed with `dnslink=`. The rest can be an `/ipfs/` link (as in the example below), or `/ipns/`, or even a link to another DNSLink.
 


### PR DESCRIPTION
This PR removes vagueness around where TXT record should be located:

- Resolving TXT records on main name works only because it is supported for legacy reasons
- putting TXT record on  `_dnslink` it is both better for opsec and performance (no unrelated TXT results) 



 
