### PR TITLE
docs: add recommendation for ipfs.io/ipfs/CID

### DIFF
--- a/docs/how-to/address-ipfs-on-web.md
+++ b/docs/how-to/address-ipfs-on-web.md
@@ -6,7 +6,17 @@ description: Hands-on guides to using and developing with IPFS to build decentra
 
 # Address IPFS on the Web
 
-This document is a guide to how to address IPFS content paths on the web.
+_How to link to content on IPFS._
+
+```
+https://ipfs.io/ipfs/<CID>
+# e.g
+https://ipfs.io/ipfs/Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiu
+```
+
+Browsers that support IPFS can redirect these requests to your local IPFS node, while those that don't can fetch the resource from the ipfs.io gateway. 
+
+You can swap out `ipfs.io` for your own http-to-ipfs gateway, but you are then obliged to keep that gateway running _forever_. If your gateway goes down, users with IPFS aware tools will still be able to fetch the content from the IPFS network as long as any node still hosts it, but for those without, the link will be broken. Don't do that.
 
 ## Dweb addressing in brief
 


### PR DESCRIPTION
Start the address-ipfs-on-the-web article with a clear recommendation for using https://ipfs.io/ipfs/<CID> when linking to content on IPFS.

Currently `ipfs add` still returns a cid v0, so it can't trivially be used in a subdomain, and many usecases (e.g NFTs) are not concerned about domain level security isolation as they point to media. They definitly dont want to be using ipfs:// scheme urls, as those only work in tools that are already ipfs aware.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>