### PR TITLE
feat: add Builders Series landing page

### DIFF
--- a/docs/welcome-builders.md
+++ b/docs/welcome-builders.md
@@ -1,0 +1,48 @@
+---
+title: IPFS Documentation
+legacyUrl: https://docs.ipfs.io/
+description: The home page for developer documentation for IPFS, the InterPlanetary File System.
+---
+
+# IPFS helps you build the future web
+
+::: callout
+**Welcome, builders!** No matter who you are or what you're creating, the InterPlanetary File System (IPFS) makes it easier for you to build the decentralized apps and services that will power the next generation of the internet.
+:::
+
+## What is IPFS?
+
+**IPFS is a content-addressed system for storing and delivering data over a globally distributed network of peers.** As a critical ingredient in a wide variety of decentralized applications and services powering the future of the internet, IPFS is an important complement to blockchains, decentralized identity, verifiable storage like [Filecoin](https://filecoin.io), and other ingredients in a distributed web (Dweb) stack.
+
+[Learn more →](/concepts/what-is-ipfs/#what-is-ipfs)
+
+## Who's building on IPFS
+**Individuals and orgs worldwide are using IPFS to build successful apps and services for a truly amazing variety of use cases and industries.** Whether you're interested in NFTs or networked communities, streaming music or social media, IPFS can play a critical part in your decentralized tech stack. Check out these resources:
+
+- [**Case Study Series**](/concepts/#examples-and-case-studies) — Success stories in industries ranging from big data to ecommerce and more.
+- [**IPFS Ecosystem Explorer**](https://ipfs.io/images/ipfs-applications-diagram.png) — See the full landscape of companies shipping apps, services, and more built on IPFS.
+- [**Awesome IPFS**](https://awesome.ipfs.io) — Community projects of all shapes and sizes, from production apps to open-source data sets to experimental repos.
+
+Or, check out the [Building Web3 video series](https://www.youtube.com/playlist?list=PL_0VrY55uV1-THfh1GVoE6v0SxKO9M0gs) to meet the visionaries who are building the future using IPFS and other web3 tools!
+
+@[youtube](d1kpID1LSRE)
+
+## IPFS and you
+
+**What can _you_ build using IPFS?** Thanks to a rapidly growing developer community, global traction for a vast variety of use cases, and active open-source development, the possibilities are virtually endless. Check out these [usage ideas and examples](concepts/usage-ideas-examples/) for inspiration, plus these pointers for getting started integrating IPFS into your project:
+
+- With implementations in [Go](https://github.com/ipfs/go-ipfs) and [JavaScript](https://js.ipfs.io/) (plus [Rust](https://github.com/rs-ipfs/rust-ipfs) in the works), options for **directly integrating IPFS into your codebase** are versatile. 
+- For **IPFS-based deployment and dev tools**, the options are growing every day — including [Fleek](https://fleek.co) (deployment, storage, and app tooling), [Textile](https://tetile.io) (databases, storage, CDN, Filecoin integration), and [Fission](https://fission.codes) (front-end app publishing using web3 back-end tools), to name just a few.
+- Want to integrate **Filecoin** into your architecture in addition to IPFS? [Learn how Filecoin and IPFS work together](https://docs.filecoin.io/about-filecoin/ipfs-and-filecoin/).
+- For hosting large amounts of data on multiple nodes, [IPFS Cluster](https://cluster.ipfs.io) helps you with **data orchestration across many peers**.
+- Or, to **ensure availability** without having to maintain your own IPFS infrastructure, you can use a [third-party pinning service](/concepts/persistence/#pinning-services) to host your files on their own nodes.
+
+## Get started right now
+
+Ready to roll up your sleeves and dive in? Start with these resources:
+
+- Just want to get hacking right away? [Install IPFS](/install/command-line/) through the command line and start exploring.
+- Check out the [**API and CLI reference guides**](/reference/) to learn more about hands-on use, or dig into the [**how-tos and tutorials**](/how-to/) here in the docs.
+- Ask questions or start a discussion in the [**official IPFS forums**](https://discuss.ipfs.io).
+- Find virtual and in-person [**hackathons and other events**](https://blog.ipfs.io/?category=Event) on the [IPFS Blog & News](https://blog.ipfs.io) page.
+- Learn the [**basics of IPFS concepts**](/concepts/) like content addressing and peer-to-peer sharing here in the docs, or try hands-on examples over at [ProtoSchool](https://proto.school).

--- a/docs/welcome-builders.md
+++ b/docs/welcome-builders.md
@@ -17,6 +17,7 @@ description: The home page for developer documentation for IPFS, the InterPlanet
 [Learn more →](/concepts/what-is-ipfs/#what-is-ipfs)
 
 ## Who's building on IPFS
+
 **Individuals and orgs worldwide are using IPFS to build successful apps and services for a truly amazing variety of use cases and industries.** Whether you're interested in NFTs or networked communities, streaming music or social media, IPFS can play a critical part in your decentralized tech stack. Check out these resources:
 
 - [**Case Study Series**](/concepts/#examples-and-case-studies) — Success stories in industries ranging from big data to ecommerce and more.


### PR DESCRIPTION
Closes #726.

### In this PR

- Adds landing page tailored to visitors from the "Building Web3: Meet the Builders" video series

### Notes

- Doesn't add a left-nav item for this page, since it's intended to supplant the main docs landing page from folks arriving from the video series
- Some items will need to be enhanced once better content is available (I have it on my personal to-do list as a followup):
     - Ecosystem directory teaser should be embedded here once it's ready (right now this just links to the raster logo parade)
     - Ditto the parts where we refer to the builders series videos; right now this just links to Textile's video, but I'll update to a playlist link once the first Meet the Builders video is added to YouTube
- @johnnymatthews, I'll have a draft of the first video for you to see in a few days — that should help contextualize the content here