### PR TITLE
docs: update remote pinning guides

### DIFF
--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -252,7 +252,7 @@ In [libp2p](#libp2p), transport refers to the technology that lets us move data 
 
 ### UnixFS
 
-The Unix File System (UnixFS) is the data format used to represent files and all their links and metadata in IPFS and is loosely based on how files work in Unix. Adding a file to IPFS creates a block (or a tree of blocks) in the UnixFS format and protects it from being garbage-collected. [More about UnixFS](https://docs.ipfs.io/concepts/file-systems/#unix-file-system-unixfs)
+The Unix File System (UnixFS) is the data format used to represent files and all their links and metadata in IPFS. It is loosely based on how files work in Unix. Adding a file to IPFS creates a block, or a _tree_ of blocks, in the UnixFS format and protects it from being garbage-collected. [More about UnixFS](https://docs.ipfs.io/concepts/file-systems/#unix-file-system-unixfs)
 
 ## V
 

--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -202,7 +202,11 @@ A Peer ID is how each unique IPFS node is identified on the network. The Peer ID
 
 ### Pinning
 
-Pinning is the method of telling an IPFS node that particular data is important and so it will never be removed from that node's cache. [More about Pinning](https://docs.ipfs.io/concepts/persistence/)
+Pinning is the method of telling an IPFS node that particular data is important and so it will never be removed from that node's cache. To learn more: understand [persistence, permanence, and pinning](/concepts/persistence/), then see how to [add local pin](/how-to/pin-files/), and read [what remote pins are](#remote-pinning).
+
+### Pinning Service API
+
+Vendor-agnostic [API specification](https://ipfs.github.io/pinning-services-api-spec/) than anyone can implement to provide a service for [remote pinning](#remote-pinning).
 
 ### Pubsub
 
@@ -211,6 +215,10 @@ Publish-subscribe (Pubsub) is an experimental feature in IPFS. Publishers send m
 ## Q
 
 ## R
+
+### Remote Pinning
+
+A variant of [pinning](#pinning) which uses a third party service to ensure that data persists on IPFS, even when local node goes offline or local copy of data is deleted during garbage collection. [More about working with remote pinning services](/how-to/work-with-pinning-services/).
 
 ### Relay
 
@@ -244,7 +252,7 @@ In [libp2p](#libp2p), transport refers to the technology that lets us move data 
 
 ### UnixFS
 
-The Unix File System (UnixFS) is the data format used to represent files and all their links and metadata in IPFS and is loosely based on how files work in Unix. Adding a file to IPFS creates a block (or a tree of blocks) in the UnixFS format. [More about UnixFS](https://docs.ipfs.io/concepts/file-systems/#unix-file-system-unixfs)
+The Unix File System (UnixFS) is the data format used to represent files and all their links and metadata in IPFS and is loosely based on how files work in Unix. Adding a file to IPFS creates a block (or a tree of blocks) in the UnixFS format and protects it from being garbage-collected. [More about UnixFS](https://docs.ipfs.io/concepts/file-systems/#unix-file-system-unixfs)
 
 ## V
 

--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -202,11 +202,11 @@ A Peer ID is how each unique IPFS node is identified on the network. The Peer ID
 
 ### Pinning
 
-Pinning is the method of telling an IPFS node that particular data is important and so it will never be removed from that node's cache. To learn more: understand [persistence, permanence, and pinning](/concepts/persistence/), then see how to [add local pin](/how-to/pin-files/), and read [what remote pins are](#remote-pinning).
+Pinning is the method of telling an IPFS node that particular data is important and so it will never be removed from that node's cache. To learn more, start by understanding [persistence, permanence, and pinning](/concepts/persistence/); then, see how to [add local pin](/how-to/pin-files/) and read [what remote pins are](#remote-pinning).
 
 ### Pinning Service API
 
-Vendor-agnostic [API specification](https://ipfs.github.io/pinning-services-api-spec/) than anyone can implement to provide a service for [remote pinning](#remote-pinning).
+A vendor-agnostic [API specification](https://ipfs.github.io/pinning-services-api-spec/) that anyone can implement to provide a service for [remote pinning](#remote-pinning).
 
 ### Pubsub
 
@@ -218,7 +218,7 @@ Publish-subscribe (Pubsub) is an experimental feature in IPFS. Publishers send m
 
 ### Remote Pinning
 
-A variant of [pinning](#pinning) which uses a third party service to ensure that data persists on IPFS, even when local node goes offline or local copy of data is deleted during garbage collection. [More about working with remote pinning services](/how-to/work-with-pinning-services/).
+A variant of [pinning](#pinning) that uses a third-party service to ensure that data persists on IPFS, even when your local node goes offline or your local copy of data is deleted during garbage collection. [More about working with remote pinning services](/how-to/work-with-pinning-services/).
 
 ### Relay
 

--- a/docs/concepts/persistence.md
+++ b/docs/concepts/persistence.md
@@ -50,14 +50,14 @@ ipfs daemon --enable-gc
 ```
 
 ::: tip
-If you use IPFS Desktop you can trigger the garbage collector by clicking on the taskbar icon of the IPFS Desktop application and selecting **Advanced** → **Run Garbage Collector**.
+If you use IPFS Desktop, you can trigger garbage collection by clicking on the taskbar icon of the IPFS Desktop application and selecting **Advanced** → **Run Garbage Collector**.
 :::
 
 ## Pinning in context
 
 An IPFS node can protect data from garbage collection based on different kinds of user events.
-- Universal way is adding a low level [local pin](/how-to/pin-files/). This works for all data types, can be done manually, but if you add a file using the CLI command [`ipfs add`](/reference/cli/#ipfs-add), the IPFS node will automatically pin that file for you.
-- When working with files and directories, a better way may be adding them to the local [Mutable File System (MFS)](/concepts/glossary/#mfs), which protects from being garbage collected the same way as local pin, but enables for easier management.
+- The universal way is by adding a low-level [local pin](/how-to/pin-files/). This works for all data types and can be done manually, but if you add a file using the CLI command [`ipfs add`](/reference/cli/#ipfs-add), your IPFS node will automatically pin that file for you.
+- When working with files and directories, a better way may be to add them to the local [Mutable File System (MFS)](/concepts/glossary/#mfs); this protects from garbage collection in the same way as local pinning, but enables for easier management.
 
 
 ::: tip

--- a/docs/concepts/persistence.md
+++ b/docs/concepts/persistence.md
@@ -57,7 +57,7 @@ If you use IPFS Desktop, you can trigger garbage collection by clicking on the t
 
 An IPFS node can protect data from garbage collection based on different kinds of user events.
 - The universal way is by adding a low-level [local pin](/how-to/pin-files/). This works for all data types and can be done manually, but if you add a file using the CLI command [`ipfs add`](/reference/cli/#ipfs-add), your IPFS node will automatically pin that file for you.
-- When working with files and directories, a better way may be to add them to the local [Mutable File System (MFS)](/concepts/glossary/#mfs); this protects from garbage collection in the same way as local pinning, but enables for easier management.
+- When working with files and directories, a better way may be to add them to the local [Mutable File System (MFS)](/concepts/glossary/#mfs). This protects the data from garbage collection in the same way as local pinning, but is somewhat easier to manage.
 
 
 ::: tip
@@ -73,4 +73,4 @@ To ensure that your important data is retained, you may want to use a pinning se
 - Your computer is a laptop, phone, or tablet that will have intermittent connectivity to the network. Still, you want to be able to access your data on IPFS from anywhere at any time, even when the device you added it from is offline.
 - You want a backup that ensures your data is always available from another computer on the network if you accidentally delete or garbage-collect your data on your own computer.
 
-Want to learn more? See how to [work with remote pinning services](/how-to/work-with-pinning-services/).
+See how to [work with remote pinning services](/how-to/work-with-pinning-services/).

--- a/docs/concepts/persistence.md
+++ b/docs/concepts/persistence.md
@@ -50,16 +50,19 @@ ipfs daemon --enable-gc
 ```
 
 ::: tip
-If you use IPFS Desktop or the IPFS Web UI the settings related to garbage collection can be found in the **Settings** tab. You can also directly run the garbage collector by clicking on the taskbar icon of the IPFS Desktop application and selecting **Advanced** → **Run Garbage Collector**.
+If you use IPFS Desktop you can trigger the garbage collector by clicking on the taskbar icon of the IPFS Desktop application and selecting **Advanced** → **Run Garbage Collector**.
 :::
 
 ## Pinning in context
 
+An IPFS node can protect data from garbage collection based on different kinds of user events.
+- Universal way is adding a low level [local pin](/how-to/pin-files/). This works for all data types, can be done manually, but if you add a file using the CLI command [`ipfs add`](/reference/cli/#ipfs-add), the IPFS node will automatically pin that file for you.
+- When working with files and directories, a better way may be adding them to the local [Mutable File System (MFS)](/concepts/glossary/#mfs), which protects from being garbage collected the same way as local pin, but enables for easier management.
+
+
 ::: tip
 If you want to learn more about how pinning fits into the overall lifecycle of data in IPFS, check out the course from [IPFS Camp _The Lifecycle of Data in DWeb_](https://www.youtube.com/watch?v=fLUq0RkiTBA).
 :::
-
-An IPFS node can store data based on different kinds of user events. For example, if you add a file using the CLI command [`ipfs add`](https://docs.ipfs.io/reference/cli/#ipfs-add), the IPFS node will automatically pin that file. It also automatically stores data you request either by loading a web page through the gateway, or with [`ipfs cat`](https://docs.ipfs.io/reference/cli/#ipfs-cat). Not every CLI command will automatically pin content.
 
 
 ## Pinning services
@@ -70,11 +73,4 @@ To ensure that your important data is retained, you may want to use a pinning se
 - Your computer is a laptop, phone, or tablet that will have intermittent connectivity to the network. Still, you want to be able to access your data on IPFS from anywhere at any time, even when the device you added it from is offline.
 - You want a backup that ensures your data is always available from another computer on the network if you accidentally delete or garbage-collect your data on your own computer.
 
-
-Some available pinning service providers are:
-
-- [Axel](https://www.axel.org/blog/2019/07/23/qa-with-the-developers-of-axel-ipfs/)
-- [Eternum](https://www.eternum.io/)
-- [Infura](https://infura.io/)
-- [Pinata](https://pinata.cloud/)
-- [Temporal](https://temporal.cloud/)
+Want to learn more? See how to [work with remote pinning services](/how-to/work-with-pinning-services/).


### PR DESCRIPTION
This PR aims to improve discoverability of docs related to local and remote pinning.

- The main goal is for user to discover guides specific to local and remote pinning when reading the explainer about persistence, permanence, and pinning. 
- Secondary goal is to remove proprietary pinning services and replace them with vendor-agnostic docs that promote `pin remote` commands added in go-ipfs 0.8.0


cc @ipfs/wg-pinning-services 