### PR TITLE
feat: add x-ipfs-path examples

### DIFF
--- a/docs/how-to/companion-x-ipfs-path-header.md
+++ b/docs/how-to/companion-x-ipfs-path-header.md
@@ -11,6 +11,14 @@ IPFS Companion can redirect traditional HTTP requests to IPFS if the `x-ipfs-pat
 
 IPFS HTTP gateways can return an `x-ipfs-path` header with each response. The value of the header is the IPFS path of the returned payload.
 
+```sh
+$ curl -sI https://en.wikipedia-on-ipfs.org | grep x-ipfs-path
+x-ipfs-path: /ipns/en.wikipedia-on-ipfs.org/
+
+$ curl -sI https://dweb.link/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi | grep x-ipfs-path
+x-ipfs-path: /ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
+```
+
 The WebExtension API [onHeadersReceived](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onHeadersReceived) can cancel and redirect the HTTP request as soon as the response headers arrive. This means the client can drop the initial request, avoiding duplicate downloads of the content.
 
 Detection of the `x-ipfs-path` header can be disabled in the _Preferences_ screen (but is enabled by default).

--- a/docs/how-to/companion-x-ipfs-path-header.md
+++ b/docs/how-to/companion-x-ipfs-path-header.md
@@ -13,13 +13,16 @@ IPFS HTTP gateways can return an `x-ipfs-path` header with each response. The va
 
 ```shell
 curl -sI https://en.wikipedia-on-ipfs.org | grep x-ipfs-path
+
 > x-ipfs-path: /ipns/en.wikipedia-on-ipfs.org/
 ```
 
 ```shell
 curl -sI https://dweb.link/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi | grep x-ipfs-path
+
 > x-ipfs-path: /ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
 ```
+````
 
 The WebExtension API [onHeadersReceived](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onHeadersReceived) can cancel and redirect the HTTP request as soon as the response headers arrive. This means the client can drop the initial request, avoiding duplicate downloads of the content.
 

--- a/docs/how-to/companion-x-ipfs-path-header.md
+++ b/docs/how-to/companion-x-ipfs-path-header.md
@@ -11,12 +11,14 @@ IPFS Companion can redirect traditional HTTP requests to IPFS if the `x-ipfs-pat
 
 IPFS HTTP gateways can return an `x-ipfs-path` header with each response. The value of the header is the IPFS path of the returned payload.
 
-```sh
-$ curl -sI https://en.wikipedia-on-ipfs.org | grep x-ipfs-path
-x-ipfs-path: /ipns/en.wikipedia-on-ipfs.org/
+```shell
+curl -sI https://en.wikipedia-on-ipfs.org | grep x-ipfs-path
+> x-ipfs-path: /ipns/en.wikipedia-on-ipfs.org/
+```
 
-$ curl -sI https://dweb.link/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi | grep x-ipfs-path
-x-ipfs-path: /ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
+```shell
+curl -sI https://dweb.link/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi | grep x-ipfs-path
+> x-ipfs-path: /ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
 ```
 
 The WebExtension API [onHeadersReceived](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onHeadersReceived) can cancel and redirect the HTTP request as soon as the response headers arrive. This means the client can drop the initial request, avoiding duplicate downloads of the content.


### PR DESCRIPTION
The page was lacking an example, this adds some.