### PR TITLE
fix example CIDs in NFT guide

### DIFF
--- a/docs/how-to/mint-nfts-with-ipfs.md
+++ b/docs/how-to/mint-nfts-with-ipfs.md
@@ -34,7 +34,7 @@ This problem was demonstrated by an artist who [_pulled the rug_](https://cointe
 
 IPFS solves this problem thanks to [Content Addressing][docs-cid]. Adding data to IPFS produces a content identifier (CID) that's directly derived from the data itself and links to the data in the IPFS network. Because a CID can only _ever_ refer to one piece of content, we know that nobody can replace or alter the content without breaking the link.
 
-Using the CID, anyone can fetch a copy of the data from the IPFS network as long as at least one copy exists on the network, even if the original provider has disappeared. This makes CIDs perfect for NFT storage. All we need to do is put the CID into an `ipfs://` URI like `ipfs://bafybeihhii26gwp4w7b7w7d57nuuqeexau4pnnhrmckikaukjuei2dl3fq/my-nft.jpeg`, and we have an immutable link from the blockchain to the data for our token.
+Using the CID, anyone can fetch a copy of the data from the IPFS network as long as at least one copy exists on the network, even if the original provider has disappeared. This makes CIDs perfect for NFT storage. All we need to do is put the CID into an `ipfs://` URI like `ipfs://bafybeidlkqhddsjrdue7y3dy27pu5d7ydyemcls4z24szlyik3we7vqvam/nft-image.png`, and we have an immutable link from the blockchain to the data for our token.
 
 Of course, there may be some cases in which you do want to change the metadata for an NFT after it's been published. That's no problem! You'll just need to add support to your smart contract for updating the URI for a token after it's been issued. That will let you change the URI to a new IPFS URI while still leaving a record of the initial version in the blockchain's transaction history. This provides accountability and makes it clear to everyone what was changed, when, and by whom.
 
@@ -346,7 +346,7 @@ The smart contract's `mintToken` function expects an IPFS metadata URI, which sh
 {
     "name": "A name for this NFT",
     "description": "An in-depth description of the NFT",
-    "image": "ipfs://bafybeihhii26gwp4w7b7w7d57nuuqeexau4pnnhrmckikaukjuei2dl3fq/nft-image.png"
+    "image": "ipfs://bafybeidlkqhddsjrdue7y3dy27pu5d7ydyemcls4z24szlyik3we7vqvam/nft-image.png"
 }
 ```
 


### PR DESCRIPTION
This fixes the example URIs in the NFT Guide to close #770.

I just updated the broken examples to `ipfs://bafybeidlkqhddsjrdue7y3dy27pu5d7ydyemcls4z24szlyik3we7vqvam/nft-image.png`, which is a pinned copy of the IPFS logo.

Thanks for reporting that @lidel, and sorry about that! I remember you made the point about invalid URIs before we published, but I must missed these.