### PR TITLE
Feat: create repo guide

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -300,6 +300,7 @@ module.exports = {
             path: '/project/',
             children: [
               'project/history',
+              'project/repository-guide',
               ['https://github.com/ipfs/roadmap', 'Roadmap'],
               'project/implementation-status',
               ['https://github.com/ipfs/specs', 'Specifications'],

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -11,6 +11,10 @@ Curious about how it all got started, or where we're headed? Learn about the his
 
 Want to know how it all began? Learn the [history of the IPFS project](/project/history/).
 
+## Repository guide
+
+IPFS is a big project, which means there are a lot of GitHub repos. If you're new to IPFS or just want a sense of what to check out first, use this quick guide to the most important and most frequently used [IPFS repositories](/project/repository-guide/).
+
 ## Roadmap
 
 See the overall roadmap of [IPFS project requirements](https://github.com/ipfs/roadmap) from current state to maturity.

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -13,7 +13,7 @@ Want to know how it all began? Learn the [history of the IPFS project](/project/
 
 ## Repository guide
 
-IPFS is a big project, which means there are a lot of GitHub repos. If you're new to IPFS or just want a sense of what to check out first, use this quick guide to the most important and most frequently used [IPFS repositories](/project/repository-guide/).
+IPFS is a big project, which means there are a lot of GitHub repos. If you're new to IPFS or just want a sense of what to check out first, use this quick guide to the most important and most frequently used [IPFS repositories](repository-guide.md).
 
 ## Roadmap
 

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -29,7 +29,7 @@ Want to know the current state of your favorite IPFS feature? See the [current i
 
 ## Research
 
-Learn more about the exploratory research work and prototyping being done for inclusion in IPFS by exploring our [research repo on GitHub](https://github.com/ipfs/research).
+Learn more about the exploratory research work and prototyping being done for inclusion in IPFS by exploring our [research repo on GitHub](https://github.com/ipfs/notes).
 
 ## IPFS team org planning
 

--- a/docs/project/repository-guide.md
+++ b/docs/project/repository-guide.md
@@ -1,0 +1,64 @@
+---
+title: Repository guide
+description: A quick guide to the most important and most frequently used IPFS repositories.
+---
+
+# IPFS repository guide
+
+This is a guide to the various GitHub orgs and repos in the IPFS project.
+
+It's not an exhaustive list of all IPFS orgs and repos, but instead is intended to help guide you based on what you are trying to do in these areas:
+
+* Fetching or developing IPFS software
+* Participate in IPFS project operations
+* Discuss ideas for using IPFS
+
+## Fetching or developing IPFS software
+
+These are the repositories of the top-level projects that we ship as part of the IPFS project, and the main repos in the stack it's built on.
+
+Protocol implementations:
+
+* go-ipfs
+* js-ipfs
+* rust
+
+Underlying components
+
+* libp2p org
+    * go-libp2p
+    * js-libp2p
+    * rust libp2p
+    * (others?)
+* ipld org
+    * ?
+* multi*
+    * ?
+
+Tools and products
+
+* IPFS Desktop
+* IPFS Companion
+* WebUI
+* GUI tools repo
+* ?
+
+Interop, Platforms & Standards
+* In Web Browsers
+* Arewedistributedyet
+* ?
+
+## Participate in IPFS project operations
+
+* ipfs/roadmap
+* ipfs/team-mgmt
+* ipfs/community
+
+IPFS websites
+* ...
+
+## Discuss ideas for using IPFS
+
+* ipfs/ipfs
+* ipfs/notes
+* ?

--- a/docs/project/repository-guide.md
+++ b/docs/project/repository-guide.md
@@ -5,9 +5,9 @@ description: A quick guide to the most important and most frequently used IPFS r
 
 # IPFS repository guide
 
-IPFS is a _big_ open-source project, and with that comes a lot of code — and a lot of issue-based discussion that goes with it. The IPFS project uses GitHub both for code development and for roadmapping and operations discussions, meaning that both types of activities can happen asynchronously, in the open, and from anywhere on the planet.
+IPFS is a _big_ open-source project, and with that comes a lot of code — and a lot of issue-based discussion that goes with it. The IPFS project uses GitHub both for code development and for road mapping and operations discussions, meaning that both types of activities can happen asynchronously, in the open, and from anywhere on the planet.
 
-If you're looking for specific IPFS-related code, or want to find where to join in a particular discussion, start with this high-level guide to the most prominent and/or frequently used GitHub orgs and repos in the IPFS project. It's not an exhaustive list of all IPFS orgs and repos, but instead is intended to help guide you based on what you are trying to do in the following areas:
+If you're looking for specific IPFS-related code, or want to find where to join in a particular discussion, start with this high-level guide to the most prominent and/or frequently used GitHub organizations and repositories in the IPFS project. It's not an exhaustive list of all IPFS organizations and repositories, but instead is intended to help guide you based on what you are trying to do in the following areas:
 
 - [Fetching or contributing to IPFS code](#fetch-or-contribute-to-ipfs-code)
 - [Participating in IPFS project operations](#participate-in-ipfs-project-operations)
@@ -15,7 +15,7 @@ If you're looking for specific IPFS-related code, or want to find where to join 
 
 ## Fetch or contribute to IPFS code
 
-Org and repo links for the top-level projects shipped as part of the IPFS project, and the main repos for each ingredient in the stack upon which IPFS is built.
+Organization and repository links for the top-level projects shipped as part of the IPFS project and the main repos for each ingredient in the stack upon which IPFS is built.
 
 ### Protocol implementations
 
@@ -62,7 +62,7 @@ Org and repo links for the top-level projects shipped as part of the IPFS projec
 
 ## Participate in IPFS project operations
 
-IPFS project operations at large are also captured in GitHub. These repos don't necessarily contain code, but do follow a similar pattern of issue creation, discussion, and resolution via comments and linked artifacts.
+IPFS project operations at large are also captured in GitHub. These repos don't necessarily contain code but do follow a similar pattern of issue creation, discussion, and resolution via comments and linked artifacts.
 
 - [IPFS Community](https://github.com/ipfs/community)
 - [IPFS Project Roadmap](https://github.com/ipfs/roadmap)
@@ -72,6 +72,6 @@ IPFS project operations at large are also captured in GitHub. These repos don't 
 
 ## Discuss ideas for using IPFS
 
-As with the IPFS project operations repos, these repositories don't necessarily contain code, but instead capture discussions, ideas, and linked artifacts in an issue-driven format.
+As with the IPFS project operations repos, these repositories don't necessarily contain code but instead capture discussions, ideas, and linked artifacts in an issue-driven format.
 
 * [ipfs/notes](https://github.com/ipfs/notes): IPFS collaborative notebook for research.

--- a/docs/project/repository-guide.md
+++ b/docs/project/repository-guide.md
@@ -46,11 +46,11 @@ Org and repo links for the top-level projects shipped as part of the IPFS projec
 ### IPFS tools and products
 
 - [IPFS Cluster](https://github.com/ipfs/ipfs-cluster): Automatically allocate, replicate, and track your data as a global pinset distributed among a swarm of peers.
-- [IPFS Companion](https://github.com/ipfs-shipyard/ipfs-companion): The IPFS web browser extension.
-- [IPFS Web UI](https://github.com/ipfs/webui): An easy-to-use web interface for IPFS nodes.
-- [IPFS Desktop](https://github.com/ipfs-shipyard/ipfs-desktop): Standalone IPFS app with an easy-to-use node interface, plus menubar/tray shortcuts
+- [IPFS Companion](https://github.com/ipfs/ipfs-companion): The IPFS web browser extension.
+- [IPFS Web UI](https://github.com/ipfs/ipfs-webui): An easy-to-use web interface for IPFS nodes.
+- [IPFS Desktop](https://github.com/ipfs/ipfs-desktop): Standalone IPFS app with an easy-to-use node interface, plus menubar/tray shortcuts
 - [ipfs-gui](https://github.com/ipfs/ipfs-gui): Coordinating development, user experience, and maintenance of IPFS GUIs.
-- [i18n](https://github.com/ipfs/i18n): The IPFS Translation Project, crowdsourcing translations of IPFS GUIs and websites.
+- [i18n](https://github.com/ipfs-shipyard/i18n): The IPFS Translation Project, crowdsourcing translations of IPFS GUIs and websites.
 - [IPFS Shipyard](https://github.com/ipfs-shipyard): GitHub org showcasing incubated projects of all types created by the global IPFS community.
 - [Testground](https://github.com/testground/testground): A platform for testing, benchmarking, and simulating distributed and p2p systems at scale.
 

--- a/docs/project/repository-guide.md
+++ b/docs/project/repository-guide.md
@@ -5,60 +5,73 @@ description: A quick guide to the most important and most frequently used IPFS r
 
 # IPFS repository guide
 
-This is a guide to the various GitHub orgs and repos in the IPFS project.
+IPFS is a _big_ open-source project, and with that comes a lot of code — and a lot of issue-based discussion that goes with it. The IPFS project uses GitHub both for code development and for roadmapping and operations discussions, meaning that both types of activities can happen asynchronously, in the open, and from anywhere on the planet.
 
-It's not an exhaustive list of all IPFS orgs and repos, but instead is intended to help guide you based on what you are trying to do in these areas:
+If you're looking for specific IPFS-related code, or want to find where to join in a particular discussion, start with this high-level guide to the most prominent and/or frequently used GitHub orgs and repos in the IPFS project. It's not an exhaustive list of all IPFS orgs and repos, but instead is intended to help guide you based on what you are trying to do in the following areas:
 
-* Fetching or developing IPFS software
-* Participate in IPFS project operations
-* Discuss ideas for using IPFS
+- [Fetching or contributing to IPFS code](#fetch-or-contribute-to-ipfs-code)
+- [Participating in IPFS project operations](#participate-in-ipfs-project-operations)
+- [Discussing ideas for using IPFS](#discuss-ideas-for-using-ipfs)
 
-## Fetching or developing IPFS software
+## Fetch or contribute to IPFS code
 
-These are the repositories of the top-level projects that we ship as part of the IPFS project, and the main repos in the stack it's built on.
+Org and repo links for the top-level projects shipped as part of the IPFS project, and the main repos for each ingredient in the stack upon which IPFS is built.
 
-Protocol implementations:
+### Protocol implementations
 
-* go-ipfs
-* js-ipfs
-* rust
+- [go-ipfs](https://github.com/ipfs/go-ipfs): The reference implementation written in Go.
+- [js-ipfs](https://github.com/ipfs/js-ipfs): The JavaScript implementation of IPFS.
+- [rust-ipfs](https://github.com/rs-ipfs/rust-ipfs): Alpha implementation in Rust.
 
-Underlying components
+### Client implementations
 
-* libp2p org
-    * go-libp2p
-    * js-libp2p
-    * rust libp2p
-    * (others?)
-* ipld org
-    * ?
-* multi*
-    * ?
+- [Current list](https://github.com/ipfs/ipfs#http-client-libraries) of HTTP client libraries.
 
-Tools and products
+### Underlying components
 
-* IPFS Desktop
-* IPFS Companion
-* WebUI
-* GUI tools repo
-* ?
+- [libp2p](https://github.com/libp2p):
+    - [go-libp2p](https://github.com/libp2p/go-libp2p): Reference libp2p implementation in Go.
+    - [js-libp2p](https://github.com/libp2p/js-libp2p): The JavaScript implementation of the libp2p networking stack.
+    - [rust-libp2p](https://github.com/libp2p/rust-libp2p): The Rust implementation of the libp2p networking stack.
+- [IPLD](https://github.com/ipld):
+    - [go-ipld](https://github.com/ipld/go-ipld): Entry-point repo for Go IPLD development.
+    - [js-ipld](https://github.com/ipld/js-ipld): The JavaScript Implementation of IPLD.
+    - [IPLD specifications](https://github.com/ipld/specs): The set of specifications that make up IPLD.
+- [Multiformats](https://github.com/multiformats):
+    - [Multiaddr](https://github.com/multiformats/multiaddr): Composable and future-proof network addresses.
+    - [Multibase](https://github.com/multiformats/multibase): Self-identifying base encodings.
+    - [Multicodec](https://github.com/multiformats/multicodec): Compact, self-describing codecs.
+    - [Multihash](https://github.com/multiformats/multihash): Self-describing hashes for future-proofing.
 
-Interop, Platforms & Standards
-* In Web Browsers
-* Arewedistributedyet
-* ?
+### IPFS tools and products
+
+- [IPFS Cluster](https://github.com/ipfs/ipfs-cluster): Automatically allocate, replicate, and track your data as a global pinset distributed among a swarm of peers.
+- [IPFS Companion](https://github.com/ipfs-shipyard/ipfs-companion): The IPFS web browser extension.
+- [IPFS Web UI](https://github.com/ipfs/webui): An easy-to-use web interface for IPFS nodes.
+- [IPFS Desktop](https://github.com/ipfs-shipyard/ipfs-desktop): Standalone IPFS app with an easy-to-use node interface, plus menubar/tray shortcuts
+- [ipfs-gui](https://github.com/ipfs/ipfs-gui): Coordinating development, user experience, and maintenance of IPFS GUIs.
+- [i18n](https://github.com/ipfs/i18n): The IPFS Translation Project, crowdsourcing translations of IPFS GUIs and websites.
+- [IPFS Shipyard](https://github.com/ipfs-shipyard): GitHub org showcasing incubated projects of all types created by the global IPFS community.
+- [Testground](https://github.com/testground/testground): A platform for testing, benchmarking, and simulating distributed and p2p systems at scale.
+
+### Interoperability, platforms, and standards
+- [IPFS Web Browsers Integration Group](https://github.com/ipfs/in-web-browsers): Tracking progress toward native IPFS support in web browsers.
+- [Are We Distributed Yet?](https://github.com/arewedistributedyet/arewedistributedyet): Prioritized listing of progress toward making peer-to-peer a first-class part of the web.
+- [IPFS Mobile Design Guidelines](https://github.com/ipfs/mobile-design-guidelines): Best practices for making IPFS work for mobile.
+- [Interoperability Tests for IPFS](https://github.com/ipfs/interop): On-the-wire interop for IPFS.
 
 ## Participate in IPFS project operations
 
-* ipfs/roadmap
-* ipfs/team-mgmt
-* ipfs/community
+IPFS project operations at large are also captured in GitHub. These repos don't necessarily contain code, but do follow a similar pattern of issue creation, discussion, and resolution via comments and linked artifacts.
 
-IPFS websites
-* ...
+- [IPFS Community](https://github.com/ipfs/community)
+- [IPFS Project Roadmap](https://github.com/ipfs/roadmap)
+- [IPFS Specifications](https://github.com/ipfs/specs)
+- [IPFS Infrastructure](https://github.com/ipfs/infra)
+- [IPFS Team Planning, Management, and Coordination](https://github.com/ipfs/team-mgmt)
 
 ## Discuss ideas for using IPFS
 
-* ipfs/ipfs
-* ipfs/notes
-* ?
+As with the IPFS project operations repos, these repositories don't necessarily contain code, but instead capture discussions, ideas, and linked artifacts in an issue-driven format.
+
+* [ipfs/notes](https://github.com/ipfs/notes): IPFS collaborative notebook for research.

--- a/docs/project/repository-guide.md
+++ b/docs/project/repository-guide.md
@@ -22,6 +22,7 @@ Organization and repository links for the top-level projects shipped as part of 
 - [go-ipfs](https://github.com/ipfs/go-ipfs): The reference implementation written in Go.
 - [js-ipfs](https://github.com/ipfs/js-ipfs): The JavaScript implementation of IPFS.
 - [rust-ipfs](https://github.com/rs-ipfs/rust-ipfs): Alpha implementation in Rust.
+- [Other implementations](https://github.com/ipfs/ipfs#protocol-implementations): Up-to-date links to all other protocol implementations.
 
 ### Client implementations
 
@@ -50,12 +51,11 @@ Organization and repository links for the top-level projects shipped as part of 
 - [IPFS Web UI](https://github.com/ipfs/ipfs-webui): An easy-to-use web interface for IPFS nodes.
 - [IPFS Desktop](https://github.com/ipfs/ipfs-desktop): Standalone IPFS app with an easy-to-use node interface, plus menubar/tray shortcuts
 - [ipfs-gui](https://github.com/ipfs/ipfs-gui): Coordinating development, user experience, and maintenance of IPFS GUIs.
-- [i18n](https://github.com/ipfs-shipyard/i18n): The IPFS Translation Project, crowdsourcing translations of IPFS GUIs and websites.
 - [IPFS Shipyard](https://github.com/ipfs-shipyard): GitHub org showcasing incubated projects of all types created by the global IPFS community.
 - [Testground](https://github.com/testground/testground): A platform for testing, benchmarking, and simulating distributed and p2p systems at scale.
 
 ### Interoperability, platforms, and standards
-- [IPFS Web Browsers Integration Group](https://github.com/ipfs/in-web-browsers): Tracking progress toward native IPFS support in web browsers.
+- [IPFS Web Browsers Integration](https://github.com/ipfs/in-web-browsers): Tracking progress toward native IPFS support in web browsers.
 - [Are We Distributed Yet?](https://github.com/arewedistributedyet/arewedistributedyet): Prioritized listing of progress toward making peer-to-peer a first-class part of the web.
 - [IPFS Mobile Design Guidelines](https://github.com/ipfs/mobile-design-guidelines): Best practices for making IPFS work for mobile.
 - [Interoperability Tests for IPFS](https://github.com/ipfs/interop): On-the-wire interop for IPFS.
@@ -64,14 +64,21 @@ Organization and repository links for the top-level projects shipped as part of 
 
 IPFS project operations at large are also captured in GitHub. These repos don't necessarily contain code but do follow a similar pattern of issue creation, discussion, and resolution via comments and linked artifacts.
 
+### Operations discussions and tools
+
 - [IPFS Community](https://github.com/ipfs/community)
 - [IPFS Project Roadmap](https://github.com/ipfs/roadmap)
 - [IPFS Specifications](https://github.com/ipfs/specs)
 - [IPFS Infrastructure](https://github.com/ipfs/infra)
 - [IPFS Team Planning, Management, and Coordination](https://github.com/ipfs/team-mgmt)
 
+### Internationalization
+
+- [i18n](https://github.com/ipfs-shipyard/i18n): The IPFS Translation Project, crowdsourcing translations of IPFS GUIs and websites.
+
 ## Discuss ideas for using IPFS
 
 As with the IPFS project operations repos, these repositories don't necessarily contain code but instead capture discussions, ideas, and linked artifacts in an issue-driven format.
 
-* [ipfs/notes](https://github.com/ipfs/notes): IPFS collaborative notebook for research.
+- [ipfs/notes](https://github.com/ipfs/notes): IPFS collaborative notebook for research.
+- [ipfs/community](https://github.com/ipfs/community/discussions): IPFS community discussions board.


### PR DESCRIPTION
Adds a guide to the most common, important or frequently used repos in the IPFS org.

Closes #669. Supersedes https://github.com/ipfs/ipfs-docs/pull/670.