### PR TITLE
Update content-addressing.md

### DIFF
--- a/docs/concepts/content-addressing.md
+++ b/docs/concepts/content-addressing.md
@@ -71,7 +71,7 @@ bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
 JavaScript users can also leverage the `toV1()` method provided by the [`cids`](https://www.npmjs.com/package/cids) library:
 ```js
 const CID = require('cids')
-new CID('QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR').toV1().toString()
+new CID('QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR').toV1().toString('base32')
 // → bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
 ```
 


### PR DESCRIPTION
Corrected JavaScript snippet to provide a `base32` string parameter to the call to `toString()` when creating a `v1` CID string using [`cids`](https://github.com/multiformats/js-cid).