### PR TITLE
Clarify progress response

### DIFF
--- a/docs/reference/http/api.md
+++ b/docs/reference/http/api.md
@@ -3173,6 +3173,9 @@ Pin objects to local storage.
 
 On success, the call to this endpoint will return with 200 and the following body:
 
+- `Pins` [string]: List of completed pins.
+- `Progress` [int]: Number of blocks pinned so far.
+
 ```json
 {
   "Pins": [


### PR DESCRIPTION
This PR adds response types that mirror the `Arguments` format, which include a description of each field

# Why?

What the progress field does has been a bit of a mystery to us at @fission-codes (and everyone we've asked) for months. We eventually ran across this answer from `@Stebalien`

https://github.com/ipfs/go-ipfs/issues/7938#issuecomment-806336540

It would be good to have this in the docs rather than have to run across a response in a GitHub Issue.

# Future Work

If it's welcome, I would like to further contribute more detailed docs for the return type that includes things like optional return fields and descriptions. @fission-suite has been building deserializers by observing responses empirically and digging through the go-ipfs source.

Please let me know if this would be welcome