### PR TITLE
fix: remove jenkins

### DIFF
--- a/docs/project/contribute.md
+++ b/docs/project/contribute.md
@@ -38,8 +38,6 @@ We do most support via the forum we have at [https://discuss.ipfs.io/](https://d
 
 We’re continuously improving IPFS every day, but mistakes can happen and we could release something that doesn’t work as well as it should — or simply doesn't work at all! If you like to dig into edge-cases or write testing scenarios, wrangling our testing infrastructure could be the job for you.
 
-We work on continuous-integration tools at [https://github.com/ipfs/jenkins](https://github.com/ipfs/jenkins) and plan larger-scale tests at [https://github.com/ipfs/kubernetes-ipfs](https://github.com/ipfs/kubernetes-ipfs).
-
 ## UX and visual design
 
 We have many design needs, but only a small team of visual and UX designers who divide their time between IPFS-related projects and other work here. That means there are a number of issues which could use your design contributions. As home to IPFS Desktop and Companion, the [ipfs-gui](https://github.com/ipfs/ipfs-gui) repo is a good place to look for opportunities to help move our design work forward. Simply filter by the label that best fits your skillset, such as [design-visual](https://github.com/ipfs/ipfs-gui/issues?q=is%3Aissue+is%3Aopen+label%3Adesign-visual) or [design-ux](https://github.com/ipfs/ipfs-gui/labels/design-ux).


### PR DESCRIPTION
Both links are archived / inactive, we moved to hosted services.