### PR TITLE
chore: go-ipfs 0.10.0

### DIFF
--- a/docs/install/command-line.md
+++ b/docs/install/command-line.md
@@ -11,11 +11,11 @@ Installing IPFS through the command-line is handy if you plan on building applic
 
 ## System requirements
 
-IPFS requires 512MiB of memory and can run an IPFS node on a Raspberry Pi. However, how much disk space your IPFS installation takes up depends on how much data you're sharing. A base installation takes up about 12MB of disk space, and the [default maximum disk storage](../how-to/configure-node.md) is set to 10GB.
+IPFS requires 512MiB of memory and can run an IPFS node on a Raspberry Pi. However, how much disk space your IPFS installation takes up depends on how much data you're sharing. A base installation takes up about 12MB of disk space. One can enable automatic garbage collection via [--enable-gc](/reference/cli/#ipfs-daemon) and adjust the [default maximum disk storage](https://github.com/ipfs/go-ipfs/blob/v0.10.0/docs/config.md#datastorestoragemax) for data retrieved from other peers.
 
 ## Official distributions
 
-The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help users quickly find the latest version of every IPFS package. As soon as a new release of an IPFS package comes out, it is automatically shown on `dist.ipfs.io`, so you can be sure you're getting the latest software. These steps detail how to download and install Go-IPFS 0.9.0 from `dist.ipfs.io` using the command-line.
+The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help users quickly find the latest version of every IPFS package. As soon as a new release of an IPFS package comes out, it is automatically shown on `dist.ipfs.io`, so you can be sure you're getting the latest software. These steps detail how to download and install the latest `go-ipfs` from `dist.ipfs.io` using the command-line.
 
 | [Windows](#windows)                                                          | [macOS](#macos)                                                        | [Linux](#linux)                                                        |
 | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
@@ -27,22 +27,22 @@ The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help 
 
    ```powershell
    cd ~\
-   wget https://dist.ipfs.io/go-ipfs/v0.9.1/go-ipfs_v0.9.1_windows-amd64.zip -Outfile go-ipfs_v0.9.1.zip
+   wget https://dist.ipfs.io/go-ipfs/v0.10.0/go-ipfs_v0.10.0_windows-amd64.zip -Outfile go-ipfs_v0.10.0.zip
    ```
 
 2. Unzip the file and move it somewhere handy.
 
    ```powershell
-   Expand-Archive -Path go-ipfs_v0.9.1.zip -DestinationPath ~\Apps\go-ipfs_v0.9.1
+   Expand-Archive -Path go-ipfs_v0.10.0.zip -DestinationPath ~\Apps\go-ipfs_v0.10.0
    ```
 
-3. Move into the `go-ipfs_v0.9.1` folder and check that the `ipfs.exe` works:
+3. Move into the `go-ipfs_v0.10.0` folder and check that the `ipfs.exe` works:
 
    ```powershell
-   cd ~\Apps\go-ipfs_v0.9.1\go-ipfs
+   cd ~\Apps\go-ipfs_v0.10.0\go-ipfs
    .\ipfs.exe --version
 
-   > ipfs version 0.9.1
+   > ipfs version 0.10.0
    ```
 
    While you can use IPFS right now, it's better to add `ipfs.exe` to your `PATH` by using the following steps.
@@ -54,13 +54,13 @@ The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help 
 
    > Path
    > ----
-   > C:\Users\Johnny\Apps\go-ipfs_v0.9.1\go-ipfs
+   > C:\Users\Johnny\Apps\go-ipfs_v0.10.0\go-ipfs
    ```
 
 5. Add the address you just copied to PowerShell's `PATH` by adding it to the end of the `profile.ps1` file stored in `Documents\WindowsPowerShell`:
 
    ```powershell
-   Add-Content C:\Users\Johnny\Documents\WindowsPowerShell\profile.ps1 "[System.Environment]::SetEnvironmentVariable('PATH',`$Env:PATH+';;C:\Users\Johnny\Apps\go-ipfs_v0.9.1\go-ipfs')"
+   Add-Content C:\Users\Johnny\Documents\WindowsPowerShell\profile.ps1 "[System.Environment]::SetEnvironmentVariable('PATH',`$Env:PATH+';;C:\Users\Johnny\Apps\go-ipfs_v0.10.0\go-ipfs')"
    ```
 
 6. Close and reopen your PowerShell window. Test that your IPFS path is set correctly by going to your home folder and asking IPFS for the version:
@@ -69,7 +69,7 @@ The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help 
    cd ~
    ipfs --version
 
-   > ipfs version 0.9.1
+   > ipfs version 0.10.0
    ```
 
 ### macOS
@@ -81,13 +81,13 @@ You can install IPFS on M1-based Macs by using the `darwin-arm64` binary instead
 1. Download the macOS binary from [`dist.ipfs.io`](https://dist.ipfs.io/#go-ipfs).
 
    ```bash
-   wget https://dist.ipfs.io/go-ipfs/v0.9.1/go-ipfs_v0.9.1_darwin-amd64.tar.gz
+   wget https://dist.ipfs.io/go-ipfs/v0.10.0/go-ipfs_v0.10.0_darwin-amd64.tar.gz
    ```
 
 1. Unzip the file:
 
    ```bash
-   tar -xvzf go-ipfs_v0.9.1_darwin-amd64.tar.gz
+   tar -xvzf go-ipfs_v0.10.0_darwin-amd64.tar.gz
 
    > x go-ipfs/install.sh
    > x go-ipfs/ipfs
@@ -111,7 +111,7 @@ You can install IPFS on M1-based Macs by using the `darwin-arm64` binary instead
    ```bash
    ipfs --version
 
-   > ipfs version 0.9.1
+   > ipfs version 0.10.0
    ```
 
 ### Linux
@@ -119,13 +119,13 @@ You can install IPFS on M1-based Macs by using the `darwin-arm64` binary instead
 1. Download the Linux binary from [`dist.ipfs.io`](https://dist.ipfs.io/#go-ipfs).
 
    ```bash
-   wget https://dist.ipfs.io/go-ipfs/v0.9.1/go-ipfs_v0.9.1_linux-amd64.tar.gz
+   wget https://dist.ipfs.io/go-ipfs/v0.10.0/go-ipfs_v0.10.0_linux-amd64.tar.gz
    ```
 
 1. Unzip the file:
 
    ```bash
-   tar -xvzf go-ipfs_v0.9.1_linux-amd64.tar.gz
+   tar -xvzf go-ipfs_v0.10.0_linux-amd64.tar.gz
 
    > x go-ipfs/install.sh
    > x go-ipfs/ipfs
@@ -149,7 +149,7 @@ You can install IPFS on M1-based Macs by using the `darwin-arm64` binary instead
    ```bash
    ipfs --version
 
-   > ipfs version 0.9.1
+   > ipfs version 0.10.0
    ```
 
 ## Compile manually

--- a/docs/install/recent-releases.md
+++ b/docs/install/recent-releases.md
@@ -6,6 +6,10 @@ title: Recent releases
 
 This section contains information about recent IPFS releases. You can find installation instructions, update information, and release notes here.
 
+## [Go-IPFS 0.10](https://github.com/ipfs/go-ipfs/releases/tag/v0.10.0)
+
+This release brings modern IPLD to IPFS, and some useful utilities.
+
 ## [Go-IPFS 0.9](https://github.com/ipfs/go-ipfs/releases/tag/v0.9.0)
 
 This release makes Go IPFS even more configurable, with some fun experiments to boot! We're also deprecating or removing some uncommonly used features to make it easier for users to discover the easy ways to use Go IPFS safely and efficiently.


### PR DESCRIPTION
I wish we could automate this, or ideally, remove the need for hardcoding version  number in the URLs (having `/latest` dir)