### PR TITLE
Removes 404ing links.

### DIFF
--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -30,7 +30,6 @@ Get the basic concepts of IPFS in one place, including:
 
 - [What is IPFS?](what-is-ipfs.md)
 - [How IPFS works](how-ipfs-works.md)
-- [IPFS primer](https://dweb-primer.ipfs.io/)
 - [Glossary](glossary.md)
 - [FAQ](faq.md)
 
@@ -77,8 +76,6 @@ IPFS aims to be the future of the internet, but it still needs to play well with
 ## Further reading
 
 Want a more in-depth look into the decentralized web? Here are a few papers that are useful for understanding IPFS, whether it be understanding the IPFS spec itself or the background for the web, protocols, hashing, and so on. [Read the papers →](further-reading/academic-papers.md)
-
-You may also be interested in the community-made [IPFS Primer →](https://dweb-primer.ipfs.io/)
 
 ## Don't see what you're looking for?
 

--- a/docs/concepts/privacy-and-encryption.md
+++ b/docs/concepts/privacy-and-encryption.md
@@ -51,7 +51,7 @@ Public IPFS gateways are primarily intended as a "bridge" between the legacy web
 
 ### Using Tor
 
-If you're familiar with [Tor](https://www.torproject.org/) and comfortable with the command line, you may wish to try [running IPFS over Tor transport](https://dweb-primer.ipfs.io/avenues-for-access/tor-transport) by configuring your node's settings.
+If you're familiar with [Tor](https://www.torproject.org/) and comfortable with the command line, you may wish to try running IPFS over Tor transport by configuring your node's settings.
 
 If you're a developer building on IPFS, it's worth noting that the global IPFS community continues to experiment with using Tor transport — see [this example from e-commerce organization OpenBazaar](https://github.com/OpenBazaar/go-onion-transport) — and there may already be an open-source codebase to help your project achieve this.
 


### PR DESCRIPTION
Issue #948 states that the dweb-primer.ipfs.io site is down. While we work on getting it back up, I'm removing the links in this repo to that site.