### PR TITLE
fix: proper noop when no http-api-updates

### DIFF
--- a/.github/actions/update-on-new-ipfs-tag/entrypoint.sh
+++ b/.github/actions/update-on-new-ipfs-tag/entrypoint.sh
@@ -42,5 +42,5 @@ else
      git add -u
      git commit -m "Bumped go-ipfs dependence of http-api-docs to tag $LATEST_IPFS_TAG."
      git push -u origin bump-http-api-docs-ipfs-to-$LATEST_IPFS_TAG
+     echo "::set-output name=updated_branch::bump-http-api-docs-ipfs-to-$LATEST_IPFS_TAG"
 fi
-echo "::set-output name=updated_branch::bump-http-api-docs-ipfs-to-$LATEST_IPFS_TAG"

--- a/.github/workflows/update-on-new-ipfs-tag.yml
+++ b/.github/workflows/update-on-new-ipfs-tag.yml
@@ -20,6 +20,7 @@ jobs:
           latest_ipfs_tag: ${{ steps.latest_ipfs.outputs.latest_tag }}
       - name: pull-request  # don't create a pr if there was no new ipfs tag
         uses: repo-sync/pull-request@65194d8015be7624d231796ddee1cd52a5023cb3 #v2.16
+        if: ${{ steps.update.outputs.updated_branch }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_branch: ${{ steps.update.outputs.updated_branch }}


### PR DESCRIPTION
@guseggert  the error was cosmetic – last step was running when it should not.
Fix from this PR skips it if there is no branch with updates.