### PR TITLE
Remove "Link a domain" DNS guide as it is wrong

### DIFF
--- a/docs/how-to/websites-on-ipfs/link-a-domain.md
+++ b/docs/how-to/websites-on-ipfs/link-a-domain.md
@@ -11,25 +11,7 @@ This section is completely optional, but following it will give you a solid gras
 
 ## Domain name service (DNS)
 
-We're going to walk through mapping a domain name to a CID. It doesn't matter which domain name registrar you use since all the steps are the same, but the links and settings will be in different places.
-
-### Things you'll need
-
-Before we get started, you will need:
-
-- A domain name.
-- The CID of your website hosted on IPFS. If you've been following this tutorial series, you should already have a website and CID ready.
-
-1. Access your registrar's control panel. You're looking for where you can manage the `CNAME` record and `TXT` records for your domain.
-1. Create a `CNAME` record.
-   a. Set the **Host** to `@`.
-   b. Set the **Value** to `gateway.ipfs.io.` Notice the trailing dot `.` at the end of `gateway.ipfs.io.`
-1. Create a `TXT` record.
-   a. Set the **Host** to `_dnslink`.
-   b. Set the value to `dnslink=/ipfs/SITE_CID`, replacing `SITE_CID` with the CID of your website.
-1. Save your changes.
-
-DNS changes can take a while to propagate through the internet. Your domain should eventually point to your IPFS hosted site! Why not try doing the same thing with the [Ethereum naming service](#ethereum-naming-service) or [Handshake](#handshake)?
+See [dnslink.io](https://dnslink.io) for explanation and instructions.
 
 ## Ethereum naming service (ENS)
 


### PR DESCRIPTION
Point to dnslink.io which explains what needs to be done in detail. We do not need to maintain duplicate docs for things.

Also the guide is wrong as it is. You cannot create a CNAME record for a root domain as it says. It needs to be an ALIAS record or an A record.