### PR TITLE
Data-not-files: IPFS 101, FAQ, & Hashing changes

### DIFF
--- a/docs/concepts/faq.md
+++ b/docs/concepts/faq.md
@@ -26,6 +26,9 @@ The quickest way to get IPFS up and running on your machine is by installing [IP
 
 For installing and initializing IPFS from the command line, check out the [command-line quick start](../how-to/command-line-quick-start.md) guide.
 
+### Why doesn't my SHA hash match my CID?
+When you add a file to IPFS, IPFS splits it into smaller blocks. Each of these pieces is hashed individually, which then results in an overall different hash. Instead, IPFS uses Merkle DAGs, which are self-verifiable. See [Merkle Directed Acyclic Graphs (DAGs)](../concepts/merkle-dag.md).
+
 ## Contributing to IPFS
 
 ### How do I start contributing to IPFS?

--- a/docs/concepts/hashing.md
+++ b/docs/concepts/hashing.md
@@ -104,4 +104,4 @@ shasum: WARNING: 1 computed checksum did NOT match
 
 As we can see, the hash included in the CID does NOT match the hash of the input file `ubuntu-20.04.1-desktop-amd64.iso`.
 
-As we can see, the hash included in the CID does NOT match the hash of the input file ubuntu-20.04.1-desktop-amd64.iso. To understand what the hash contained in the CID is, we must understand how IPFS stores files. IPFS uses a directed acyclic graph (DAG) to keep track of all the data stored in IPFS. A CID identifies one specific node in this graph. This identifier is the result of hashing the node's contents using a cryptographic hash function like SHA256.
+As we can see, the hash included in the CID does not match the hash of the input file ubuntu-20.04.1-desktop-amd64.iso. To understand what the hash contained in the CID is, we must understand how IPFS stores files. IPFS uses a directed acyclic graph (DAG) to keep track of all the data stored in IPFS. A CID identifies one specific node in this graph. This identifier is the result of hashing the node's contents using a cryptographic hash function like SHA256.

--- a/docs/concepts/hashing.md
+++ b/docs/concepts/hashing.md
@@ -35,6 +35,7 @@ For example, the SHA-256 hash of "Hello world" from above can be represented as 
 ```
 mtwirsqawjuoloq2gvtyug2tc3jbf5htm2zeo4rsknfiv3fdp46a
 ```
+
 ::: tip
 If you're interested in how cryptographic hashes fit into how IPFS works with files in general, check out this video from IPFS Camp 2019! [Core Course: How IPFS Deals With Files](https://www.youtube.com/watch?v=Z5zNPwMDYGg)
 :::

--- a/docs/concepts/hashing.md
+++ b/docs/concepts/hashing.md
@@ -52,7 +52,7 @@ These features also mean we can use a cryptographic hash to identify any piece o
 
 That's critical for a distributed system like IPFS, where we want to be able to store and retrieve data from many places. A computer running IPFS can ask all the peers it's connected to whether they have a file with a particular hash and, if one of them does, they send back the whole file. Without a short, unique identifier like a cryptographic hash, this kind of [content addressing](content-addressing.md) wouldn't be possible.
 
-## Example: Content Identifier doesn't match file hash
+## Example: Content Identifiers are not file hashes
 
 Hash functions are widely used to check for file integrity. Because IPFS splits content into blocks and verifies them through [directed acyclic graphs (DAGs)](../concepts/merkle-dag.md), SHA file hashes won't match CIDs. Here's an example of what will happen if you try to do that.
 
@@ -103,3 +103,5 @@ shasum: WARNING: 1 computed checksum did NOT match
 ```
 
 As we can see, the hash included in the CID does NOT match the hash of the input file `ubuntu-20.04.1-desktop-amd64.iso`.
+
+As we can see, the hash included in the CID does NOT match the hash of the input file ubuntu-20.04.1-desktop-amd64.iso. To understand what the hash contained in the CID is, we must understand how IPFS stores files. IPFS uses a directed acyclic graph (DAG) to keep track of all the data stored in IPFS. A CID identifies one specific node in this graph. This identifier is the result of hashing the node's contents using a cryptographic hash function like SHA256.

--- a/docs/concepts/hashing.md
+++ b/docs/concepts/hashing.md
@@ -39,7 +39,7 @@ mtwirsqawjuoloq2gvtyug2tc3jbf5htm2zeo4rsknfiv3fdp46a
 If you're interested in how cryptographic hashes fit into how IPFS works with files in general, check out this video from IPFS Camp 2019! [Core Course: How IPFS Deals With Files](https://www.youtube.com/watch?v=Z5zNPwMDYGg)
 :::
 
-## Characteristics of hashes
+## Important hash characteristics
 
 Cryptographic hashes come with a couple of very important characteristics:
 
@@ -52,17 +52,11 @@ These features also mean we can use a cryptographic hash to identify any piece o
 
 That's critical for a distributed system like IPFS, where we want to be able to store and retrieve data from many places. A computer running IPFS can ask all the peers it's connected to whether they have a file with a particular hash and, if one of them does, they send back the whole file. Without a short, unique identifier like a cryptographic hash, this kind of [content addressing](content-addressing.md) wouldn't be possible.
 
-## Content identifiers are not file hashes
+## Example: Content Identifier doesn't match file hash
 
-When you add a file to IPFS, IPFS splits it into chunks. Each chunk represents a node in the tree structure, called a Directed Acyclic Graph (DAG). IPFS creates a CID for each node in this structure, including separate CIDs for any parent nodes. The DAG keeps track of all the content stored in IPFS (as chunks, not files), so don't be surprised when a SHA hash doesn't match a CID.
+Hash functions are widely used to check for file integrity. Because IPFS splits content into blocks and verifies them through [directed acyclic graphs (DAGs)](../concepts/merkle-dag.md), SHA file hashes won't match CIDs. Here's an example of what will happen if you try to do that.
 
-With IPFS, you don't use SHA hashes to check the integrity of a file. To learn more about how IPFS keeps track of data, see [directed acyclic graph (DAG)](merkle-dag.md).
-
-To understand how a CID is broken down, see the [CID Inpsector](../concepts/content-addressing/#cid-inspector). <!--What link format are we suppose to use. I see several formats. -->
-
-<!-- Concerning the below text: Are we basically saying: "This is why you can't use hash functions to check file integrity with IPFS."? If so, I don't think we want to be in the business of describing what doesn't work. We might like to delete all of the below. -->
-
-Hash functions are widely used as to check for file integrity. A download provider may publish the output of a hash function for a file, often called a _checksum_. The checksum enables users to verify that a file has not been altered since it was published. This check is done by performing the same hash function against the downloaded file that was used to generate the checksum. If that checksum that the user receives from the downloaded file exactly matches the checksum on the website, then the user knows that the file was not altered and can be trusted.
+A download provider may publish the output of a hash function for a file, often called a _checksum_. The checksum enables users to verify that a file has not been altered since it was published. This check is done by performing the same hash function against the downloaded file that was used to generate the checksum. If that checksum that the user receives from the downloaded file exactly matches the checksum on the website, then the user knows that the file was not altered and can be trusted.
 
 Let's look at a concrete example. When you download an image file for [Ubuntu Linux](https://ubuntu.com/) you might see the following `SHA-256` checksum on the Ubuntu website listed for verification purposes:
 

--- a/docs/concepts/how-ipfs-works.md
+++ b/docs/concepts/how-ipfs-works.md
@@ -72,13 +72,15 @@ There are [other content replication protocols under discussion](https://github.
 
 ## SHA file hashes won't match Content IDs
 
-You may be used to verifying the integrity of a file by matching SHA hashes, but don't be surprised when a SHA hash doesn't match a CID. Because IPFS splits a file into blocks, each block has its own CID, including separate CIDs for any parent nodes. The DAG keeps track of all the content stored in IPFS as blocks, not files. So CIDs will not match SHA hashes.
+You may be used to verifying the integrity of a file by matching SHA hashes, but SHA hashes won't match CIDs. Because IPFS splits a file into blocks, each block has its own CID, including separate CIDs for any parent nodes.
 
-With IPFS, don't expect to use SHA hashes to check the integrity of a file. Merkle DAGs are self-verified structures. To learn more about DAGs, see [directed acyclic graph (DAG)](../concepts/merkle-dag.md).
+The DAG keeps track of all the content stored in IPFS as blocks, not files, and Merkle DAGs are self-verified structures. To learn more about DAGs, see [directed acyclic graph (DAG)](../concepts/merkle-dag.md).
+
+For a detailed example of what happens when you try to compare SHA hashes with CIDs, see [Content Identifiers are not hashes](../concepts/hashing/#content-identifiers-are-not-file-hashes).
 
 ### Libp2p
 
-What makes libp2p especially useful for peer to peer connections is _connection multiplexing_. Traditionally, every service in a system opens a different connection to communicate with other services of the same kind remotely. Using IPFS, you open just one connection, and you multiplex everything on that. For everything your peers need to talk to each other about, you send a little bit of each thing, and the other end knows how to sort those chunks where they belong.
+What makes libp2p especially useful for peer-to-peer connections is _connection multiplexing_. Traditionally, every service in a system opens a different connection to communicate with other services of the same kind remotely. Using IPFS, you open just one connection, and you multiplex everything on that. For everything your peers need to talk to each other about, you send a little bit of each thing, and the other end knows how to sort those chunks where they belong.
 
 This is useful because establishing connections is usually hard to set up and expensive to maintain. With multiplexing, once you have that connection, you can do whatever you need on it.
 

--- a/docs/concepts/how-ipfs-works.md
+++ b/docs/concepts/how-ipfs-works.md
@@ -36,11 +36,13 @@ Many distributed systems make use of content addressing through hashes as a mean
 
 This is where the [Interplanetary Linked Data (IPLD) project](https://ipld.io/) comes in. IPLD translates between hash-linked data structures allowing for the unification of the data across distributed systems. IPLD provides libraries for combining pluggable modules (parsers for each possible type of IPLD node) to resolve a path, selector, or query across many linked nodes, allowing you to explore data regardless of the underlying protocol. IPLD provides a way to translate between content-addressable data structures: _"Oh, you use Git-style, no worries, I can follow those links. Oh, you use Ethereum, I got you, I can follow those links too!"_
 
-IPFS follows particular data-structure preferences and conventions. The IPFS protocol uses those conventions and IPLD to get from raw content to an IPFS address that uniquely identifies content on the IPFS network. The next section explores how links between content are embedded within that content address through a DAG data structure.
+IPFS follows particular data-structure preferences and conventions. The IPFS protocol uses those conventions and IPLD to get from raw content to an IPFS address that uniquely identifies content on the IPFS network.
+
+The next section explores how links between content are embedded within that content address through a DAG data structure.
 
 ## Directed acyclic graphs (DAGs)
 
-IPFS and many other distributed systems take advantage of a data structure called [directed acyclic graphs](https://en.wikipedia.org/wiki/Directed_acyclic_graph), or DAGs. Specifically, they use _Merkle DAGs_, which are DAGs where each node has a unique identifier that is a hash of the node's contents. Sound familiar? This refers back to the _CID_ concept that we covered in the previous section. Put another way: identifying a data object (like a Merkle DAG node) by the value of its hash _is content addressing_. Check out our [guide to Merkle DAGs](merkle-dag.md) for a more in-depth treatment of this topic.
+IPFS and many other distributed systems take advantage of a data structure called [directed acyclic graphs](https://en.wikipedia.org/wiki/Directed_acyclic_graph), or DAGs. Specifically, they use _Merkle DAGs_, where each node has a unique identifier that is a hash of the node's contents. Sound familiar? This refers back to the _CID_ concept that we covered in the previous section. Put another way: identifying a data object (like a Merkle DAG node) by the value of its hash _is content addressing_. Check out our [guide to Merkle DAGs](merkle-dag.md) for a more in-depth treatment of this topic.
 
 IPFS uses a Merkle DAG that is optimized for representing directories and files, but you can structure a Merkle DAG in many different ways. For example, Git uses a Merkle DAG that has many versions of your repo inside of it.
 
@@ -67,6 +69,12 @@ Once you know where your content is (or, more precisely, which peers are storing
 You've discovered your content, and you've found the current location(s) of that content. Now, you need to connect to that content and get it (_exchange_). To request blocks from and send blocks to other peers, IPFS currently uses a module called [_Bitswap_](https://github.com/ipfs/specs/blob/master/BITSWAP.md). Bitswap allows you to connect to the peer or peers that have the content you want, send them your _wantlist_ (a list of all the blocks you're interested in), and have them send you the blocks you requested. Once those blocks arrive, you can verify them by hashing their content to get CIDs and compare them to the CIDs that you requested. These CIDs also allow you to deduplicate blocks if needed.
 
 There are [other content replication protocols under discussion](https://github.com/ipfs/camp/blob/master/DEEP_DIVES/24-replication-protocol.md) as well, the most developed of which is [_Graphsync_](https://github.com/ipld/specs/blob/master/block-layer/graphsync/graphsync.md). There's also a proposal under discussion to [extend the Bitswap protocol](https://github.com/ipfs/go-bitswap/issues/186) to add functionality around requests and responses.
+
+## SHA file hashes won't match Content IDs
+
+You may be used to verifying the integrity of a file by matching SHA hashes, but don't be surprised when a SHA hash doesn't match a CID. Because IPFS splits a file into blocks, each block has its own CID, including separate CIDs for any parent nodes. The DAG keeps track of all the content stored in IPFS as blocks, not files. So CIDs will not match SHA hashes.
+
+With IPFS, don't expect to use SHA hashes to check the integrity of a file. Merkle DAGs are self-verified structures. To learn more about DAGs, see [directed acyclic graph (DAG)](../concepts/merkle-dag.md).
 
 ### Libp2p
 


### PR DESCRIPTION
Changes 3 files to address this issue (Answers issue https://github.com/ipfs/ipfs-docs/issues/996):

- IPFS 101 (How it works): The ideal place for the answer to 'Why doesn't my SHA hash match my CID' is in the introductory, high-level doc, as it addresses a naive question.
- FAQ: I don't like repeating in doc, but I believe FAQs are the one exception: They should actually be a restatement--said in a concise way--to deflect constant questions to the team.
- Hashing: The bottom section was kind of the start of the whole thing. The answer isn't really gotten to until the bottom (like a mystery novel, inductive reasoning). I suggest using deductive reasoning (state the thesis first) in technical writing. Also, It seems to me that we're explaining precisely, step-by-step, how NOT to do something, which is kind of weird (Open the door to the oven while the cake is baking; Darn, that won't work! Oops, the cake collapsed, too late.) If I had it my way, I would not get in that business, but Volker and Johnny seem to value it (and, as engineers, they represent our audience), so I moved the heart of the answer up top ( the "this won't work" part....made it deductive), a little word-smithing, and clarified the heading, so they know what they're getting into.

After examining the overall Info Architecture of the IPFS doc, I think this repetition is fine: High level for newbies, occasional FAQs to reduce user frustration and save our time, and a detailed explanation for our nerdy friends.