### PR TITLE
Replaces chat links with Discord.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,6 @@ Are you looking for inspiration? You can find a huge collection of awesome commu
 
 ## Be part of the IPFS community
 
-IPFS has a bustling community of designers, developers, writers, and activists who are all helping to improve the project. You can join in by attending a local meetup, helping out at a conference, chatting online through [Matrix channels](community/chat.md), or joining a discussion in [the IPFS forum](https://discuss.ipfs.io/).
+IPFS has a bustling community of designers, developers, writers, and activists who are all helping to improve the project. You can join in by attending a local meetup, helping out at a conference, chatting online through [Discord](https://discord.com/invite/KKucsCpZmY), or joining a discussion in [the IPFS forum](https://discuss.ipfs.io/).
 
 [Find out more in the Community section →](community/README.md)

--- a/docs/community/chat.md
+++ b/docs/community/chat.md
@@ -6,26 +6,10 @@ description: How to connect with the IPFS community using synchronous chat.
 
 # Chat
 
-## Matrix
-
-If synchronous chat is your go-to for discussions and help on dev topics, there are several Matrix channels on `ipfs.io` dedicated to IPFS and related topic, it’s a great place for live chat:
-
-- Use [`#lobby:ipfs.io`](https://matrix.to/#/#lobby:ipfs.io) for general IPFS usage and community chat.
-- Topical rooms:
-  - [`#ipld:ipfs.io`](https://matrix.to/#/#ipld:ipfs.io)
-  - [`#libp2p:ipfs.io`](https://matrix.to/#/#libp2p:ipfs.io)
-  - Want to chat Filecoin? [Join the community here](https://github.com/filecoin-project/community#join-the-community).
-
 ## Discord
 
-The IPFS Matrix and Discord communities are mostly bridged. If you'd prefer to use Discord instead of Matrix, simply join [here](https://discord.gg/Z4H6tdECb9)!
+Join the [IPFS Discord server](https://discord.com/invite/KKucsCpZmY) for synchronous chat!
 
-## Matrix and the forums
+## Forums
 
 For longer-lived discussions and for support, please use the discussion forums at [https://discuss.ipfs.io](https://discuss.ipfs.io) instead! It’s easy for complex discussions to get lost in a sea of new messages on chat, and posting longer discussions and support requests on the forums help future visitors, too.
-
-## Getting started with Matrix
-
-If you’re new to Matrix, there are _lots_ of mobile and desktop clients for working with it. Here are a few to get you started:
-
-- [Element](https://element.io/) on the web, desktop and mobile

--- a/docs/how-to/command-line-quick-start.md
+++ b/docs/how-to/command-line-quick-start.md
@@ -189,4 +189,4 @@ You need to install and set up FUSE in order to mount the file system. For more 
 
 ### Further help
 
-The IPFS community is friendly and able to help! Get support from other IPFS developers in the official [IPFS forums](https://discuss.ipfs.io/), or join the conversation on [Matrix](../community/chat.md).
+The IPFS community is friendly and able to help! Get support from other IPFS developers in the official [IPFS forums](https://discuss.ipfs.io/), or join the conversation on [Discord](https://discord.com/invite/KKucsCpZmY).


### PR DESCRIPTION
As per https://github.com/protocol/docs/issues/9, replaces old and dull Slack and Matrix links with brand new and shiny Discord links.