### PR TITLE
Remove duplicated info (ciskip)

### DIFF
--- a/docs/concepts/immutability.md
+++ b/docs/concepts/immutability.md
@@ -50,9 +50,6 @@ If we change the content of `B` to `IPFS!`, all the upstream paths will change a
 "hello"    "world"     "hello"    "IPFS!"
 ```
 
-Again, node `B` does not change. It will always refer to the same content, `world`. Node `A` also appears in the new DAG. This is not because we are _keeping_ it; that would imply the location-addressed paradigm. In the content-addressed system, any time someone writes a block with `"hello"`, it will _always_ have CID `A`.
-This is different from location-addressed systems where we could reuse the original buffer and edit the small substring that represents the difference.
-
 Again, node `B` does not change. It will always refer to the same content, `world`. Node `A` also appears in the new DAG. This does not necessarily mean we copied the memory/buffer that contained the `hello` string into our new message; that would imply the location-addressed paradigm that focuses on the _where_ and not the _what_. In a content-addressed system, any time someone writes the string `hello` it will always have CID `A`, regardless of whether we copied the string from a previous location or we wrote it from scratch.
 
 ## Website explanation


### PR DESCRIPTION
The page about [Immutablility](https://docs.ipfs.io/concepts/immutability/) contains almost the same paragraph twice. I think this was added by mistake and I would argue it doesn't really added anything for the reader. However, you might want to keep it anyway.

With this PR, I'm suggesting to remove the duplicated paragraph keeping the more recent version (added in https://github.com/ipfs/ipfs-docs/commit/95fbcea4200353d256b660867ee001bb3c2d0b26). 

(It's kind of ironic that the change to the paragraph itself is of the style "hello world" -> "hello IPFS!")