### PR TITLE
Removes discovery-transfer redundancies

### DIFF
--- a/docs/concepts/bitswap.md
+++ b/docs/concepts/bitswap.md
@@ -33,13 +33,13 @@ Want-list {
 
 #### Discovery
 
-To find peers that have a file, a node running the Bitswap protocol first sends a request called a _want-have_ to all the peers it is connected to. This _want-have_ request contains the CID of the root block of the file (the root block is at the top of the DAG of blocks that make up the file). Peers that have the root block send a _have_ response and are added to a session. Peers that don't have the block send a _dont-have_ response. If none of the peers have the root block, Bitswap queries the Distributed Hash Table (DHT) to ask who can provide the root block.
+To find peers that have a file, a node running the Bitswap protocol first sends a request called a _want-have_ to all the peers it is connected to. This _want-have_ request contains the CID of the root block of the file (the root block is at the top of the DAG of blocks that make up the file). Peers that have the root block send a _have_ response and are added to a session. Peers that don't have the block send a _dont-have_ response. Bitswap builds up a map of which nodes have and don't have each block.
 
 ![Diagram of the _want-have/want-block_ process.](./images/bitswap/diagram-of-the-want-have-want-block-process.png =740x537)
 
 #### Transfer
 
-Once peers have been added to a session, for each block that the client wants, Bitswap sends _want-have_ to each session peer to find out which peers have the block. Peers respond with _have_ or _dont_have_. Bitswap builds up a map of which nodes have and don't have each block. Bitswap sends _want-block_ to peers that have the block, and they respond with the block itself. If no peers have the block, Bitswap queries the DHT to find providers who have the block.
+Bitswap sends _want-block_ to peers that have the block, and they respond with the block itself. If none of the peers have the root block, Bitswap queries the Distributed Hash Table (DHT) to ask who can provide the root block.
 
 ### Additional references
 


### PR DESCRIPTION
The discovery paragraph had some Transfer information and the Transfer paragraph repeated some discovery information. Sorted them out.
Also, moved the last sentence from Discovery to the last sentence in Transfer to explain what happens if the transfer doesn't work.