### PR TITLE
Adds reviewers suggestions for CLI Nodes

### DIFF
--- a/docs/install/command-line.md
+++ b/docs/install/command-line.md
@@ -176,7 +176,7 @@ The command line can detect and use any node that's running, unless it's configu
 
 ### Local daemon
 
-The local daemon process is automatically started in the CLI with `ipfs daemon`. It creates an `$IPFS_PATH/api` file with an [RPC API](./reference/http/api/#http-rpc-api-reference) address.
+The local daemon process is automatically started in the CLI with the command `ipfs daemon`. It creates an `$IPFS_PATH/api` file with an [RPC API](./reference/http/api/#http-rpc-api-reference) address.
 
 ### Remote client
 

--- a/docs/install/command-line.md
+++ b/docs/install/command-line.md
@@ -170,6 +170,32 @@ You can install IPFS on M1-based Macs by using the `darwin-arm64` binary instead
 
 Manually compiling IPFS is a fairly involved process that changes frequently. It can be handy if you'd like to build a specific branch or use the _bleeding-edge_ version of Go-IPFS. See the [`ipfs/go-ipfs` GitHub repository for details →](https://github.com/ipfs/go-ipfs)
 
+## Which node should you use with the command line
+
+The command line can detect and use any node that's running, unless it's configured to use an external binary file. Here's which node to use for the local daemon or a remote client:
+
+### Local daemon
+
+The local daemon process is automatically started in the CLI with `ipfs daemon`. It creates an `$IPFS_PATH/api` file with an [RPC API](./reference/http/api/#http-rpc-api-reference) address.
+
+### Remote client
+
+You can install the standalone IPFS CLI client independently and use it to talk to an IPFS Desktop node or a Brave node. Use the [RPC API](./reference/http/api/#http-rpc-api-reference) to talk to the `ipfs` daemon.
+
+When an IPFS command is executed without parameters, the CLI client checks whether the `$IPFS_PATH/api` file exists and connects to the address listed there.
+
+- If an `$IPFS_PATH` is in the default location (for example, `~/.ipfs` on Linux), then it works automatically and the IPFS CLI client talks to the locally running `ipfs` daemon without any additional configuration.
+
+- If an `$IPFS_PATH` is not in the default location, use the `--api <rpc-api-addr>` command-line argument. Alternatively, you can set the environment variable to `IPFS_PATH`. `IPFS_PATH` will point to a directory with the api file with the existing `ipfs` daemon instance.
+
+#### Most common examples
+
+If you are an IPFS Desktop user, you can install CLI tools and an `.ipfs/api` file is automatically picked up.
+
+If you're not running IPFS Desktop, specify a custom port with `ipfs --api /ip4/127.0.0.1/tcp/<port> id` in the CLI.
+
+For example, Brave RPC API runs on port 45001, so the CLI can talk to the Brave daemon using `ipfs --api /ip4/127.0.0.1/tcp/45001 id`. You can use `mkdir -p ~/.ipfs && echo "/ip4/<ip>/tcp/<rpc-port>" > ~/.ipfs/api` to avoid passing `--api` every time.
+
 ## Next steps
 
 Now that you've got an IPFS node installed, you can start building applications and services on top of the network! Check out the Command-line- quicks start guide and jump straight to the [Initialize the repository section](../how-to/command-line-quick-start.md#initialize-the-repository).

--- a/docs/install/ipfs-desktop.md
+++ b/docs/install/ipfs-desktop.md
@@ -62,7 +62,7 @@ Or, if you'd rather use a package manager, check this [list of third-party packa
 
    ![The IPFS Desktop status bar menu in the Windows status bar.](./images/ipfs-desktop/install-windows-ipfs-desktop-status-bar.png)
 
-The IPFS Desktop application has finished installing. You can now start to [add your site](#add-your-site).
+The IPFS Desktop application has finished installing. You can now start to [add your site](./how-to/websites-on-ipfs/single-page-website/#add-your-site).
 
 ## macOS
 
@@ -113,7 +113,7 @@ While these instructions are specific to Ubuntu, they will likely work with most
 ### Install using AppImage
 
 :::warning
-When installing IPFS Desktop using an AppImage executable, you will not have access to the command-line `ipfs` commands. This limitation is due to how AppImages work and how they containerize their processes. 
+When installing IPFS Desktop using an AppImage executable, you will not have access to the command-line `ipfs` commands. This limitation is due to how AppImages work and how they containerize their processes.
 
 If you are certain that you do not need to use the command-line `ipfs` commands, then go ahead and install the AppImage. Otherwise, consider using the [deb installer ↑](#install-with-deb)
 :::


### PR DESCRIPTION
This PR is a correction to #1063, to which I mistakenly added a #1068  file. I will NEVER do that again (I hope).

In install > command-line.md:

- Adds Johnny's suggestions.  (except for the sentence: "The local daemon process is automatically started in the CLI with the command `ipfs daemon`." ...I realized they were talking about the actual command to run the daemon.)

- Divides long complex sentence into three.

- Clarifies that the second example (not on the Desktop) is in the CLI.

In install > ipfs-desktop.md:
fixes broken link