### PR TITLE
Fixes typos in k51 explanation

### DIFF
--- a/docs/concepts/ipns.md
+++ b/docs/concepts/ipns.md
@@ -59,7 +59,7 @@ When looking up an IPNS address, use the `/ipns/` prefix:
    > Published to k51qzi5uqu5dkkciu33khkzbcmxtyhn376i1e83tya8kuy7z9euedzyr5nhoew: /ipfs/QmUVTKsrYJpaxUT7dr9FpKq6AoKHhEM7eG1ZHGL56haKLG
    ```
 
-    `k51...` is the public key or IPNS name of the IPFS you are running. You can now change the file repeatedly, and even though the CID changes when you change the file, you can continue to access it with this key
+   `k51...` is the public key or IPNS name of the IPFS you are running. You can now change the file repeatedly, and, even though the CID changes when you change the file, you can continue to access it with this key.
 
 1. You can view your file by going to `https://gateway.ipfs.io/ipns/k51qzi5uqu5dkkciu33khkzbcmxtyhn376i1e83tya8kuy7z9euedzyr5nhoew`:
 


### PR DESCRIPTION
For the explanation of K51, deleted initial space in paragraph, and added a comma after and and a period.