### PR TITLE
Adds new page with 4 best practices

### DIFF
--- a/docs/how-to/best-practices-for-ipfs-builders
+++ b/docs/how-to/best-practices-for-ipfs-builders
@@ -1,0 +1,65 @@
+---
+title: Best practices for IPFS builders
+description: Some IPFS features are disabled or not defaults, but we encourage their use under the right circumstances. We list them here for easy access by busy builders.
+date: 2022-03-11
+---
+
+# Best practices for IPFS builders
+
+Some IPFS features are not enabled or set as defaults, but we encourage you to use them under the right circumstances. We list them here for easy access.
+
+## When is CIDv1 the best choice
+
+There are two versions of CIDs (Content Identifiers), CIDv0 and CIDv1.
+
+CIDv0 is simpler but much less flexible than CIDv1. It doesn't offer the future-proof and case-insensitive addressing that CIDv1 offers. Many of the existing IPFS tools still generate CIDs in v0. [examples?]
+
+Some features use CIDv1 by default:
+- `files` ([Mutable File System](file-systems.md#mutable-file-system-mfs))
+- `object` operations
+
+Use CIDv1 when you want:
+- future-proof addressing
+- case-insensitive addressing
+
+To opt in, use a version flag in the CLI: `ipfs add --cid-version 1`.
+
+To differentiate between hashes already created, notice that CIDv0 starts with `Qm`.
+
+For more information on content addressing and CID versions, see [Content Addressing and CIDs](https://docs.ipfs.io/concepts/content-addressing/#content-addressing-and-cids).
+
+## Enable pubsub if you need fast IPNS
+
+`pubsub` is one of the available options for configuring your IPFS node. It allows you to publish and subscribe to messages on a given topic.
+
+`pubsub` is an experimental feature. It's not intended in its current state to be used in a production environment, so it's disabled by default.  
+
+To use this feature, enable it when you run the daemon in the CLI with `ipfs --enable-pubsub-experiment`.
+
+See [ipfs pubsub](../reference/cli/#ipfs-pubsub) for information on the available subcommands.
+
+## Enable Garbage Collection if your data churn is expected to be high
+
+Storage is finite, so nodes need to clear out some of their previously cached resources to make room for new resources. This process is called garbage collection.
+
+If you expect your data churn to be high, you may want to enable garbage collection to reclaim memory occupied by objects that are no longer in use.
+
+However, you may also have data that you value. To make sure that you keep data that is valuable to you, pin the valued data. See:
+- [Persistence, permanence, and pinning](../concepts/persistence/#persistence-permanence-and-pinning)
+- [Pinning in context](https://docs.ipfs.io/concepts/persistence/#pinning-in-context)
+- [Pin files using IPFS](./how-to/pin-files/#three-kinds-of-pins).
+
+Then you can safely enable garbage collection for all other data. See:
+- [Garbage collection](../concepts/persistence/#garbage-collection)
+- [api/v0/repo/gc](../reference/http/api/#api-v0-repo-gc)
+
+## Use subdomain gateways or DNSLink when publishing apps for secure context and origin isolation
+
+To prevent one website from improperly accessing HTTP session data associated with a different website, use a:
+- subdomain gateway, or
+- DNSLink
+
+See:
+- [Violation of same-origin policy](../concepts/ipfs-gateway/#limitations-and-potential-workarounds)
+-[Subdomain gateway](./how-to/address-ipfs-on-web/#subdomain-gateway)
+-[DNSLink gateway](./how-to/address-ipfs-on-web/#http-gateways)


### PR DESCRIPTION
Creates a new page with these 4 best practices:

- use cidv1 for future-proof addressing, and use in case-insensitive contexts
- enable pubsub if you need fast IPNS
- enable GC if your data churn is expected to be high
- use subdomain gateways or DNSLink when publishing apps

@johnnymatthews : How do I get the new page into the directory? I'm thinking it should go into Customize your install, right before Troubleshooting.