### PR TITLE
Update configure-node.md

### DIFF
--- a/docs/how-to/configure-node.md
+++ b/docs/how-to/configure-node.md
@@ -696,8 +696,11 @@ Type: `string`
 
 ## `Pubsub`
 
-Pubsub configures the `ipfs pubsub` subsystem. To use, it must be enabled by
-passing the `--enable-pubsub-experiment` flag to the daemon.
+Pubsub allows you to publish and subscribe to messages on a given topic. To enable it, use the `--enable-pubsub-experiment` flag to the daemon.
+
+```shell
+ipfs pubsub --enable-pubsub-experiment
+```
 
 ### `Pubsub.Router`
 


### PR DESCRIPTION
Clarifies definition of `pubsub` .

@lidel should we give this here too:

To use this feature, use `Ipns.UsePubsub` before starting the IPFS daemon:

```shell
ipfs config --json Ipns.UsePubsub true
ipfs daemon
```