### PR TITLE
fix: glossary link to better gateway docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,9 @@ Check out these docs to get started with IPFS:
 - [API and CLI references](reference/README.md)
 - [Install IPFS](install/README.md)
 
+<abbr title="too long; didn't read">TL;DR</abbr>? [Glossary](concepts/glossary.md) provides short definitions of IPFS terms and concepts.
+
+
 ## Download IPFS tools
 
 These tools can help you use and build on IPFS more quickly and efficiently — give them a try today!

--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -184,7 +184,7 @@ An experimental data store used when `--nocopy` is passed to `ipfs add`. It stor
 
 ### Gateway
 
-An IPFS Gateway acts as a bridge between traditional web browsers and IPFS. Through the gateway, users can browse files and websites stored in IPFS as if they were stored on a traditional web server. [More about Gateway](https://github.com/ipfs/go-ipfs/blob/master/docs/gateway.md)
+An IPFS Gateway acts as a bridge between traditional web browsers and IPFS. Through the gateway, users can browse files and websites stored in IPFS as if they were stored on a traditional web server. [More about Gateway](../concepts/ipfs-gateway.md) and [addressing IPFS on the web](../how-to/address-ipfs-on-web.md)
 
 ### Garbage Collection
 


### PR DESCRIPTION
Linking to the same docs as in https://github.com/ipfs/go-ipfs/pull/8825