### PR TITLE
fix(ci): update on new go ipfs automation

### DIFF
--- a/.github/actions/update-on-new-ipfs-tag/entrypoint.sh
+++ b/.github/actions/update-on-new-ipfs-tag/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eu
 
 API_FILE=`pwd`/docs/reference/http/api.md

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,8 @@ updates:
       include: 'scope'
     labels:
       - 'dependencies'
+  - package-ecosystem: 'gomod'
+    directory: 'tools/http-api-docs/' # Location of go package manifests
+    open-pull-requests-limit: 0 # Disable dependabot for go deps, we want them rock solid
+    ignore:
+      dependency-name: "go-ipfs" # explicit ignore just in case, because this is handled by  .github/workflows/update-on-new-ipfs-tag.yml

--- a/docs/install/command-line.md
+++ b/docs/install/command-line.md
@@ -1,7 +1,7 @@
 ---
 title: Command-line
 description: Using IPFS through the command-line allows you to do everything that IPFS Desktop can do, but at a more granular level since you can specify which commands to run. Learn how to install it here.
-current-ipfs-version: v0.12.0
+current-ipfs-version: v0.12.2
 ---
 
 # Command-line
@@ -12,7 +12,7 @@ Installing IPFS through the command-line is handy if you plan on building applic
 
 ## System requirements
 
-IPFS requires 512MiB of memory and can run an IPFS node on a Raspberry Pi. However, how much disk space your IPFS installation takes up depends on how much data you're sharing. A base installation takes up about 12MB of disk space. One can enable automatic garbage collection via [--enable-gc](/reference/cli/#ipfs-daemon) and adjust the [default maximum disk storage](https://github.com/ipfs/go-ipfs/blob/v0.12.0/docs/config.md#datastorestoragemax) for data retrieved from other peers.
+IPFS requires 512MiB of memory and can run an IPFS node on a Raspberry Pi. However, how much disk space your IPFS installation takes up depends on how much data you're sharing. A base installation takes up about 12MB of disk space. One can enable automatic garbage collection via [--enable-gc](/reference/cli/#ipfs-daemon) and adjust the [default maximum disk storage](https://github.com/ipfs/go-ipfs/blob/v0.12.2/docs/config.md#datastorestoragemax) for data retrieved from other peers.
 
 ## Official distributions
 
@@ -28,19 +28,19 @@ The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help 
 
    ```powershell
    cd ~\
-   wget https://dist.ipfs.io/go-ipfs/v0.12.0/go-ipfs_v0.12.0_windows-amd64.zip -Outfile go-ipfs_v0.12.0.zip
+   wget https://dist.ipfs.io/go-ipfs/v0.12.2/go-ipfs_v0.12.2_windows-amd64.zip -Outfile go-ipfs_v0.12.2.zip
    ```
 
 1. Unzip the file and move it somewhere handy.
 
    ```powershell
-   Expand-Archive -Path go-ipfs_v0.12.0.zip -DestinationPath ~\Apps\go-ipfs_v0.12.0
+   Expand-Archive -Path go-ipfs_v0.12.2.zip -DestinationPath ~\Apps\go-ipfs_v0.12.2
    ```
 
-1. Move into the `go-ipfs_v0.12.0` folder and check that the `ipfs.exe` works:
+1. Move into the `go-ipfs_v0.12.2` folder and check that the `ipfs.exe` works:
 
    ```powershell
-   cd ~\Apps\go-ipfs_v0.12.0\go-ipfs
+   cd ~\Apps\go-ipfs_v0.12.2\go-ipfs
    .\ipfs.exe --version
 
    > ipfs version 0.12.0
@@ -96,13 +96,13 @@ You can install IPFS on M1-based Macs by using the `darwin-arm64` binary instead
 1. Download the macOS binary from [`dist.ipfs.io`](https://dist.ipfs.io/#go-ipfs).
 
    ```bash
-   curl -O https://dist.ipfs.io/go-ipfs/v0.12.0/go-ipfs_v0.12.0_darwin-amd64.tar.gz
+   curl -O https://dist.ipfs.io/go-ipfs/v0.12.2/go-ipfs_v0.12.2_darwin-amd64.tar.gz
    ```
 
 1. Unzip the file:
 
    ```bash
-   tar -xvzf go-ipfs_v0.12.0_darwin-amd64.tar.gz
+   tar -xvzf go-ipfs_v0.12.2_darwin-amd64.tar.gz
 
    > x go-ipfs/install.sh
    > x go-ipfs/ipfs
@@ -134,13 +134,13 @@ You can install IPFS on M1-based Macs by using the `darwin-arm64` binary instead
 1. Download the Linux binary from [`dist.ipfs.io`](https://dist.ipfs.io/#go-ipfs).
 
    ```bash
-   wget https://dist.ipfs.io/go-ipfs/v0.12.0/go-ipfs_v0.12.0_linux-amd64.tar.gz
+   wget https://dist.ipfs.io/go-ipfs/v0.12.2/go-ipfs_v0.12.2_linux-amd64.tar.gz
    ```
 
 1. Unzip the file:
 
    ```bash
-   tar -xvzf go-ipfs_v0.12.0_linux-amd64.tar.gz
+   tar -xvzf go-ipfs_v0.12.2_linux-amd64.tar.gz
 
    > x go-ipfs/install.sh
    > x go-ipfs/ipfs


### PR DESCRIPTION
This PR should fix automation that runs on new go-ipfs release:
- [fix: Syntax error: redirection unexpected](https://github.com/ipfs/ipfs-docs/commit/43068812a2a399b5d9f0d2a7bee524ee65374df4)
  The `sh` provided by CI uses a different shell than bash, so `<<<` used below did not work ([CI failure](https://github.com/ipfs/ipfs-docs/runs/6116796964?check_suite_focus=true#step:5:20) - this should fix it.
  https://github.com/ipfs/ipfs-docs/blob/b7aef5c8b4fc5e6efd46fe9e48b618f208353edb/.github/actions/update-on-new-ipfs-tag/entrypoint.sh#L35
- [fix: go-ipfs docs generation](https://github.com/ipfs/ipfs-docs/commit/9e5fa3c2096aecbf2d0afa1c8683cbd251c802eb)
  Dependabot was updating go-ipfs dependency in `tools/http-api-docs/go.mod` (example: https://github.com/ipfs/ipfs-docs/pull/1109), which means our automation from `.github/workflows/update-on-new-ipfs-tag.yml` thought we already have all versions up to date and did not  run for 0.12.1 and 0.12.2 :see_no_evil: 
  This PR disables dependabot for `tools/http-api-docs/go.mod` deps, making sure our generator does not get broken silently
- [chore: update docs manually](https://github.com/ipfs/ipfs-docs/commit/63171dfea8b5283f45e152c231df7b78783a0c70)
  one-time fix to get us up-to-speed
  (already fixed HTTP RPC docs in https://github.com/ipfs/ipfs-docs/pull/1086, these are remaining updates were missed because of bugs fixed above)