### PR TITLE
Fixing image display error in docs/README.md [styling bug]

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ These tools can help you use and build on IPFS more quickly and efficiently — 
 
 | [Browser Companion](https://github.com/ipfs-shipyard/ipfs-companion)            | [IPFS Desktop](https://github.com/ipfs-shipyard/ipfs-desktop)                                          | [IPLD Explorer](https://explore.ipld.io/)                           |
 | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
-| ![The IPFS browser companion in Firefox.](./images/ipfs-companion.png =300x200) | ![The IPFS desktop app running on MacOS with the status tab open.](./images/ipfs-desktop.png =300x200) | ![The IPLD Explorer homepage.](./images/ipld-explorer.png =300x200) |
+| ![The IPFS browser companion in Firefox.](./images/ipfs-companion.png) | ![The IPFS desktop app running on MacOS with the status tab open.](./images/ipfs-desktop.png) | ![The IPLD Explorer homepage.](./images/ipld-explorer.png) |
 
 ## Host your website on IPFS
 


### PR DESCRIPTION
The image sizing method doesn't work in the markdown parser. I removed it as the image size is correct and will fit perfectly in the table. It's displaying now.