### PR TITLE
Adds script to change version numbers in files.

### DIFF
--- a/scripts/update-version-numbers.py
+++ b/scripts/update-version-numbers.py
@@ -1,0 +1,37 @@
+# Search for version numbers from a list of pages
+# and updates those versions to the lastest available
+# version for that particular app/program/project.
+
+import requests
+import json
+import re
+
+# Dictionary of pages to edit.
+pages_to_update = {
+    "docs/install/command-line.md": "ipfs/go-ipfs",
+    "docs/install/ipfs-updater.md": "ipfs/ipfs-update",
+    "docs/install/server-infrastructure.md": "ipfs/ipfs-cluster"
+}
+
+# Loop through each pages_to_update.
+for page_path in pages_to_update:
+
+    # Read file.
+    with open("../" + page_path, "r") as page_file:
+        page_content = page_file.read()
+
+    # Define org and repo. 
+    org_and_repo = pages_to_update.get(page_path) 
+
+    # Grab version from GitHub API.
+    response = requests.get('https://api.github.com/repos/' + org_and_repo + '/releases/latest', headers={'Accept': 'application/vnd.github.v3+json'}) 
+    json_reponse = json.loads(response.text)
+    version_number = json_reponse["tag_name"]
+
+    # Find and replace version numbers in page.
+    updated_page_content = re.sub("v\d{1,2}\.\d{1,2}\.\d{1,2}", version_number, page_content)
+
+    # Write changes to page.
+    page_open = open("../" + page_path, "w")
+    page_open.write(updated_page_content)
+    page_open.close()


### PR DESCRIPTION
Closes https://github.com/ipfs/ipfs-docs/issues/1128

Adds a script to automatically update version numbers in certain pages, based off what those pages are about. 

[Lines 10 to 14](https://github.com/ipfs/ipfs-docs/pull/1130/files#diff-c69efaf29770bf1208564588f21088c83f33b817c0b7c1f238a6b83e8dcb2d92R10-R14) reference which files need to be changes, and which repos they're concerned with.

```python
pages_to_update = {
    "docs/install/command-line.md": "ipfs/go-ipfs",
    "docs/install/ipfs-updater.md": "ipfs/ipfs-update",
    "docs/install/server-infrastructure.md": "ipfs/ipfs-cluster"
}
```

[Lines 26 to 29](https://github.com/ipfs/ipfs-docs/pull/1130/files#diff-c69efaf29770bf1208564588f21088c83f33b817c0b7c1f238a6b83e8dcb2d92R26-R29) get the latest version number from the GitHub API.

```python
# Grab version from GitHub API.
response = requests.get('https://api.github.com/repos/' + org_and_repo + '/releases/latest', headers={'Accept': 'application/vnd.github.v3+json'}) 
json_reponse = json.loads(response.text)
version_number = json_reponse["tag_name"]
```

[Line 32](https://github.com/ipfs/ipfs-docs/pull/1130/files#diff-c69efaf29770bf1208564588f21088c83f33b817c0b7c1f238a6b83e8dcb2d92R32) performs the Regex magic to replace `vX.XX.XX` with the appropriate version number:

```python
updated_page_content = re.sub("v\d{1,2}\.\d{1,2}\.\d{1,2}", version_number, page_content)
```



