### PR TITLE
Remove broken link to canny

### DIFF
--- a/docs/.vuepress/theme/components/LegacyCallout.vue
+++ b/docs/.vuepress/theme/components/LegacyCallout.vue
@@ -14,14 +14,6 @@
               >Suggest new content</a
             >
           </li>
-          <li>
-            <a
-              href="https://ipfs.canny.io/docs-features"
-              target="_blank"
-              rel="noopener noreferrer"
-              >Request features</a
-            >
-          </li>
         </ul>
       </div>
       <div class="block">


### PR DESCRIPTION
We no longer use canny for feature requests. 

This PR removes the link from the callout. 