### PR TITLE
fix: detect new go-ipfs tag using github releases

### DIFF
--- a/.github/actions/latest-ipfs-tag/entrypoint.sh
+++ b/.github/actions/latest-ipfs-tag/entrypoint.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env sh
 set -eu
 
+# extract tag name from latest stable release
+REPO="ipfs/go-ipfs"
+LATEST_IPFS_TAG=$(curl -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${INPUT_REPOSITORY}/releases/latest" | jq --raw-output ".tag_name")
+
 # extract IPFS release
 cd /tmp
-git clone https://github.com/ipfs/go-ipfs.git
+git clone "https://github.com/$REPO.git"
 cd go-ipfs
-LATEST_IPFS_TAG=`git describe --tags --abbrev=0`
+
+# confirm tag is valid
+LATEST_IPFS_TAG=$(git describe --tags "${LATEST_VERSION_TAG}")
 echo "The latest IPFS tag is ${LATEST_IPFS_TAG}"
 echo "::set-output name=latest_tag::${LATEST_IPFS_TAG}"


### PR DESCRIPTION
This will check the latest stable release, which will always do the right thing.

## Why old way was buggy?

Old version assumed the latest tag without revision suffix is the latest release but it is not always the case (error prone).

For example, we now have 0.13, but:

```console
$ git clone https://github.com/ipfs/go-ipfs.git
$ cd go-ipfs
$ git describe --tags --abbrev=0
v0.12.2
$ git describe --tags
v0.12.2-506-gb36044be3
```
