### PR TITLE
Adds `sudo` to `bash install.sh` command

### DIFF
--- a/docs/install/command-line.md
+++ b/docs/install/command-line.md
@@ -116,7 +116,7 @@ You can install IPFS on M1-based Macs by using the `darwin-arm64` binary instead
 
    ```bash
    cd kubo
-   bash install.sh
+   sudo bash install.sh
 
    > Moved ./ipfs to /usr/local/bin
    ```


### PR DESCRIPTION
Found out the other day that when attempting to install on macos, running just `bash install.sh` will move the binary but return an error. Then if you attempt the install again using `sudo` it will return an error of `mv: ./ipfs: no such file or directory` because the first attempt already moved the binary. If this happens, users need to start from the beginning and re-download the binary, this time using `sudo`.