### PR TITLE
update eth.link to eth.limo

### DIFF
--- a/docs/how-to/websites-on-ipfs/link-a-domain.md
+++ b/docs/how-to/websites-on-ipfs/link-a-domain.md
@@ -15,7 +15,7 @@ See [dnslink.io](https://dnslink.io) for explanation and instructions.
 
 ## Ethereum naming service (ENS)
 
-The Ethereum naming service (ENS) is a decentralized way to address resources. Like DNS, which converts human-readable names to IP addresses, ENS converts human-readable names such as `randomplanetfacts.eth.link` to Ethereum addresses. These addresses can then be used to point to CIDs on IPFS. Without going into too much detail, ENS aims to fix some of DNS's problems, mainly man-in-the-middle attacks and scalability. For more information on why DNS is broken, [check out Cynthia Taylor's post on recompilermag.com](https://recompilermag.com/issues/issue-1/the-web-is-broken-how-dns-breaks-almost-every-design-principle-of-the-internet/).
+The Ethereum naming service (ENS) is a decentralized way to address resources. Like DNS, which converts human-readable names to IP addresses, ENS converts human-readable names such as `randomplanetfacts.eth.limo` to Ethereum addresses. These addresses can then be used to point to CIDs on IPFS. Without going into too much detail, ENS aims to fix some of DNS's problems, mainly man-in-the-middle attacks and scalability. For more information on why DNS is broken, [check out Cynthia Taylor's post on recompilermag.com](https://recompilermag.com/issues/issue-1/the-web-is-broken-how-dns-breaks-almost-every-design-principle-of-the-internet/).
 
 ### Things you'll need 
 
@@ -96,7 +96,7 @@ The more years you choose to prepay, the less you will spend on gas fees overall
 
 In a few minutes, you'll be able to go to `Your_Domain.eth/` and view your website. Note the trailing slash `/`. Because `.eth` is not a registered DNS top-level domain, it is normally inaccessible through regular browsers.
 
-[Eth.link](https://eth.link/) provides a way for any browser to access your website. Just append `.link` to your domain. For example, `Your_Domain.eth.link`. There are no additional steps required for this.
+[Eth.limo](https://eth.limo/) provides a way for any browser to access your website. Just append `.limo` to your domain. For example, `Your_Domain.eth.limo`. There are no additional steps required for this.
 
 ## Handshake 
 


### PR DESCRIPTION
The domain for eth.link has expired and the current owner is unknown.
I would propose to link to eth.limo instead.