### PR TITLE
chore: switch to dist.ipfs.tech

### DIFF
--- a/docs/how-to/address-ipfs-on-web.md
+++ b/docs/how-to/address-ipfs-on-web.md
@@ -96,7 +96,7 @@ https://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq.ipfs.localho
 
 #### Native support in Kubo 0.5+
 
-[Kubo](https://dist.ipfs.io/#kubo) provides native support for subdomain gateways on hostnames defined in the [`Gateway.PublicGateways`](https://github.com/ipfs/kubo/blob/master/docs/config.md#gatewaypublicgateways) configuration map.
+[Kubo](https://dist.ipfs.tech/#kubo) provides native support for subdomain gateways on hostnames defined in the [`Gateway.PublicGateways`](https://github.com/ipfs/kubo/blob/master/docs/config.md#gatewaypublicgateways) configuration map.
 
 Learn more about daemon configuration for hosting a public gateway:
 

--- a/docs/how-to/default-profile.md
+++ b/docs/how-to/default-profile.md
@@ -108,14 +108,14 @@ The above command shows the difference between your existing IPFS configuration 
 
 ## Converting profiles
 
-Not all profiles are compatible with each other, because they may use different technologies for storing the data inside the datastores. For instance, if you want to convert `badgerds` to `default-datastore`, you have to use another helper tool called [ipfs-ds-convert](https://dist.ipfs.io/#ipfs-ds-convert) to convert the datastore to the required format. Please follow the instructions given below to install `ipfs-ds-convert` for your operating system.
+Not all profiles are compatible with each other, because they may use different technologies for storing the data inside the datastores. For instance, if you want to convert `badgerds` to `default-datastore`, you have to use another helper tool called [ipfs-ds-convert](https://dist.ipfs.tech/#ipfs-ds-convert) to convert the datastore to the required format. Please follow the instructions given below to install `ipfs-ds-convert` for your operating system.
 
 ### MacOS
 
 Download the tarball for MacOS, extract the contents, and move the binary file to your path:
 
 ```bash
-wget -O /tmp/ipfs-ds-convert.tar.gz https://dist.ipfs.io/ipfs-ds-convert/v0.5.0/ipfs-ds-convert_v0.5.0_darwin-amd64.tar.gz
+wget -O /tmp/ipfs-ds-convert.tar.gz https://dist.ipfs.tech/ipfs-ds-convert/v0.5.0/ipfs-ds-convert_v0.5.0_darwin-amd64.tar.gz
 sudo tar -xzvf /tmp/ipfs-ds-convert.tar.gz -C /usr/local/bin/ --strip-components=1
 sudo chmod +x /usr/local/bin/ipfs-ds-convert
 rm /tmp/ipfs-ds-convert.tar.gz
@@ -126,7 +126,7 @@ rm /tmp/ipfs-ds-convert.tar.gz
 Download the tarball for Linux, extract the contents, and move the binary file to your path:
 
 ```bash
-wget -O /tmp/ipfs-ds-convert.tar.gz https://dist.ipfs.io/ipfs-ds-convert/v0.5.0/ipfs-ds-convert_v0.5.0_linux-amd64.tar.gz
+wget -O /tmp/ipfs-ds-convert.tar.gz https://dist.ipfs.tech/ipfs-ds-convert/v0.5.0/ipfs-ds-convert_v0.5.0_linux-amd64.tar.gz
 sudo tar -xzvf /tmp/ipfs-ds-convert.tar.gz -C /usr/local/bin/ --strip-components=1
 sudo chmod +x /usr/local/bin/ipfs-ds-convert
 rm /tmp/ipfs-ds-convert.tar.gz
@@ -136,10 +136,10 @@ rm /tmp/ipfs-ds-convert.tar.gz
 
 Download the zip file, extract it and then add the path to `ipfs-ds-convert.exe` to your environment path:
 
-- Download the zip package from here: [ipfs-ds-convert](https://dist.ipfs.io/ipfs-ds-convert/v0.5.0/ipfs-ds-convert_v0.5.0_windows-amd64.zip) and extract it.
+- Download the zip package from here: [ipfs-ds-convert](https://dist.ipfs.tech/ipfs-ds-convert/v0.5.0/ipfs-ds-convert_v0.5.0_windows-amd64.zip) and extract it.
 - Add the full path to `ipfs-ds-convert.exe` to your environment variables path.
 
-To find more about `ipfs-ds-convert` please visit here: [ipfs-ds-convert](https://dist.ipfs.io/#ipfs-ds-convert).
+To find more about `ipfs-ds-convert` please visit here: [ipfs-ds-convert](https://dist.ipfs.tech/#ipfs-ds-convert).
 Once you are done with the installation process, verify that `ipfs-ds-convert` has been installed successfully by executing the following command:
 
 ```bash

--- a/docs/install/command-line.md
+++ b/docs/install/command-line.md
@@ -16,7 +16,7 @@ Kubo IPFS requires 512MiB of memory and can run an IPFS node on a Raspberry Pi. 
 
 ## Official distributions
 
-The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help users quickly find the latest version of every IPFS package. As soon as a new release of an IPFS package comes out, it is automatically shown on `dist.ipfs.io`, so you can be sure you're getting the latest software. These steps detail how to download and install the latest `kubo` from `dist.ipfs.io` using the command-line.
+The IPFS team manages the [dist.ipfs.tech website](https://dist.ipfs.tech/) to help users quickly find the latest version of every IPFS package. As soon as a new release of an IPFS package comes out, it is automatically shown on `dist.ipfs.tech`, so you can be sure you're getting the latest software. These steps detail how to download and install the latest `kubo` from `dist.ipfs.tech` using the command-line.
 
 | [Windows](#windows)                                                          | [macOS](#macos)                                                        | [Linux](#linux)                                                        |
 | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
@@ -24,11 +24,11 @@ The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help 
 
 ### Windows
 
-1. Download the Windows binary from [`dist.ipfs.io`](https://dist.ipfs.io/#kubo).
+1. Download the Windows binary from [`dist.ipfs.tech`](https://dist.ipfs.tech/#kubo).
 
    ```powershell
    cd ~\
-   wget https://dist.ipfs.io/kubo/v0.14.0/kubo_v0.14.0_windows-amd64.zip -Outfile kubo_v0.14.0.zip
+   wget https://dist.ipfs.tech/kubo/v0.14.0/kubo_v0.14.0_windows-amd64.zip -Outfile kubo_v0.14.0.zip
    ```
 
 1. Unzip the file and move it somewhere handy.
@@ -93,10 +93,10 @@ The IPFS team manages the [dist.ipfs.io website](https://dist.ipfs.io/) to help 
 You can install IPFS on M1-based Macs by using the `darwin-arm64` binary instead of the `amd64` binary listed in these instructions.
 :::
 
-1. Download the macOS binary from [`dist.ipfs.io`](https://dist.ipfs.io/#kubo).
+1. Download the macOS binary from [`dist.ipfs.tech`](https://dist.ipfs.tech/#kubo).
 
    ```bash
-   curl -O https://dist.ipfs.io/kubo/v0.14.0/kubo_v0.14.0_darwin-amd64.tar.gz
+   curl -O https://dist.ipfs.tech/kubo/v0.14.0/kubo_v0.14.0_darwin-amd64.tar.gz
    ```
 
 1. Unzip the file:
@@ -131,10 +131,10 @@ You can install IPFS on M1-based Macs by using the `darwin-arm64` binary instead
 
 ### Linux
 
-1. Download the Linux binary from [`dist.ipfs.io`](https://dist.ipfs.io/#kubo).
+1. Download the Linux binary from [`dist.ipfs.tech`](https://dist.ipfs.tech/#kubo).
 
    ```bash
-   wget https://dist.ipfs.io/kubo/v0.14.0/kubo_v0.14.0_linux-amd64.tar.gz
+   wget https://dist.ipfs.tech/kubo/v0.14.0/kubo_v0.14.0_linux-amd64.tar.gz
    ```
 
 1. Unzip the file:

--- a/docs/install/ipfs-updater.md
+++ b/docs/install/ipfs-updater.md
@@ -10,15 +10,15 @@ The IPFS updater is a command-line tool originally used to help users update the
 
 ## Install updater
 
-You can download pre-built binaries from [`dist.ipfs.io`](https://dist.ipfs.io/#ipfs-update). Binaries are also available from the [IPFS Update GitHub release page](https://github.com/ipfs/ipfs-update/releases).
+You can download pre-built binaries from [`dist.ipfs.tech`](https://dist.ipfs.tech/#ipfs-update). Binaries are also available from the [IPFS Update GitHub release page](https://github.com/ipfs/ipfs-update/releases).
 
 ### Windows
 
-1. Download the Windows binary from [`dist.ipfs.io`](https://dist.ipfs.io/#ipfs-update).
+1. Download the Windows binary from [`dist.ipfs.tech`](https://dist.ipfs.tech/#ipfs-update).
 
    ```powershell
    cd ~
-   wget https://dist.ipfs.io/ipfs-update/v1.8.0/ipfs-update_v1.8.0_windows-amd64.zip -Outfile ipfs-update_v1.8.0_windows-amd64.zip
+   wget https://dist.ipfs.tech/ipfs-update/v1.8.0/ipfs-update_v1.8.0_windows-amd64.zip -Outfile ipfs-update_v1.8.0_windows-amd64.zip
    ```
 
 2. Unzip the file and move it somewhere handy:
@@ -87,10 +87,10 @@ You can download pre-built binaries from [`dist.ipfs.io`](https://dist.ipfs.io/#
 
 ### macOS
 
-1. Download the macOS binary from [`dist.ipfs.io`](https://dist.ipfs.io/#ipfs-update).
+1. Download the macOS binary from [`dist.ipfs.tech`](https://dist.ipfs.tech/#ipfs-update).
 
    ```bash
-   curl -O https://dist.ipfs.io/ipfs-update/v1.8.0/ipfs-update_v1.8.0_darwin-amd64.tar.gz
+   curl -O https://dist.ipfs.tech/ipfs-update/v1.8.0/ipfs-update_v1.8.0_darwin-amd64.tar.gz
    ```
 
 2. Unzip the file:
@@ -121,10 +121,10 @@ You can download pre-built binaries from [`dist.ipfs.io`](https://dist.ipfs.io/#
 
 ### Linux
 
-1. Download the Linux binary from [`dist.ipfs.io`](https://dist.ipfs.io/#ipfs-update).
+1. Download the Linux binary from [`dist.ipfs.tech`](https://dist.ipfs.tech/#ipfs-update).
 
    ```bash
-   wget https://dist.ipfs.io/ipfs-update/v1.8.0/ipfs-update_v1.8.0_linux-amd64.tar.gz
+   wget https://dist.ipfs.tech/ipfs-update/v1.8.0/ipfs-update_v1.8.0_linux-amd64.tar.gz
    ```
 
 2. Unzip the file:

--- a/docs/install/server-infrastructure.md
+++ b/docs/install/server-infrastructure.md
@@ -35,10 +35,10 @@ If you're having issues here, head over to the [official Docker documentation to
 
 ### Steps
 
-1. Download the latest `ipfs-cluster-ctl` package from [dist.ipfs.io](https://dist.ipfs.io/#ipfs-cluster-ctl):
+1. Download the latest `ipfs-cluster-ctl` package from [dist.ipfs.tech](https://dist.ipfs.tech/#ipfs-cluster-ctl):
 
     ```shell
-    wget https://dist.ipfs.io/ipfs-cluster-ctl/v1.0.2/ipfs-cluster-ctl_v1.0.2_linux-amd64.tar.gz
+    wget https://dist.ipfs.tech/ipfs-cluster-ctl/v1.0.2/ipfs-cluster-ctl_v1.0.2_linux-amd64.tar.gz
     ```
 
 1. Unzip the package:


### PR DESCRIPTION
> Part of https://github.com/protocol/bifrost-infra/issues/2018

This PR replaces `dist.ipfs.io` with `dist.ipfs.tech`