### PR TITLE
Fixed broken link (404)

### DIFF
--- a/docs/how-to/run-ipfs-inside-docker.md
+++ b/docs/how-to/run-ipfs-inside-docker.md
@@ -100,7 +100,7 @@ docker run -d --name ipfs \
 ```
 
 :::tip Use in custom images
-See the `gateway` example on the [go-ipfs-docker examples repository](https://github.com/ipfs-shipyard/go-ipfs-docker-examples)
+See the `gateway` example on the [go-ipfs-docker-examples repository](https://github.com/ipfs-shipyard/go-ipfs-docker-examples)
 :::
 
 ## Private swarms inside Docker

--- a/docs/how-to/run-ipfs-inside-docker.md
+++ b/docs/how-to/run-ipfs-inside-docker.md
@@ -100,7 +100,7 @@ docker run -d --name ipfs \
 ```
 
 :::tip Use in custom images
-See `gateway` example at[github.com/ipfs-shipyard/go-ipfs-docker-examples](https://github.com/ipfs-shipyard/go-ipfs-docker-examples)
+See the `gateway` example on the [go-ipfs-docker examples repository](https://github.com/ipfs-shipyard/go-ipfs-docker-examples)
 :::
 
 ## Private swarms inside Docker

--- a/docs/how-to/run-ipfs-inside-docker.md
+++ b/docs/how-to/run-ipfs-inside-docker.md
@@ -100,7 +100,7 @@ docker run -d --name ipfs \
 ```
 
 :::tip Use in custom images
-See `gateway` example at[github.com/ipfs-shipyard/kubo-docker-examples](https://github.com/ipfs-shipyard/kubo-docker-examples)
+See `gateway` example at[github.com/ipfs-shipyard/go-ipfs-docker-examples](https://github.com/ipfs-shipyard/go-ipfs-docker-examples)
 :::
 
 ## Private swarms inside Docker


### PR DESCRIPTION
`https://github.com/ipfs-shipyard/kubo-docker-examples` points to a non-existent page.