### PR TITLE
Fix links in IPFS desktop page

### DIFF
--- a/docs/install/ipfs-desktop.md
+++ b/docs/install/ipfs-desktop.md
@@ -62,7 +62,7 @@ Or, if you'd rather use a package manager, check this [list of third-party packa
 
    ![The IPFS Desktop status bar menu in the Windows status bar.](./images/ipfs-desktop/install-windows-ipfs-desktop-status-bar.png)
 
-The IPFS Desktop application has finished installing. Now, learn how to [host a website using IPFS →](../how-to/websites-on-ipfs/single-page-website.md).
+The IPFS Desktop application has finished installing. Now, [add your site](../how-to/websites-on-ipfs/single-page-website.md#add-your-site).
 
 ## macOS
 
@@ -93,8 +93,7 @@ The IPFS Desktop application has finished installing. Now, learn how to [host a 
 
    ![The IPFS Desktop status bar menu in the macOS status bar.](./images/ipfs-desktop/install-macos-ipfs-desktop-status-bar.png)
 
-The IPFS Desktop application has finished installing. Now, learn how to [host a website using IPFS →](../how-to/websites-on-ipfs/single-page-website.md).
-
+The IPFS Desktop application has finished installing. Now, [add your site](../how-to/websites-on-ipfs/single-page-website.md#add-your-site).
 
 ## Ubuntu
 

--- a/docs/install/ipfs-desktop.md
+++ b/docs/install/ipfs-desktop.md
@@ -62,7 +62,7 @@ Or, if you'd rather use a package manager, check this [list of third-party packa
 
    ![The IPFS Desktop status bar menu in the Windows status bar.](./images/ipfs-desktop/install-windows-ipfs-desktop-status-bar.png)
 
-The IPFS Desktop application has finished installing. You can now start to [add your site](./how-to/websites-on-ipfs/single-page-website/#add-your-site).
+The IPFS Desktop application has finished installing. Now, learn how to [host a website using IPFS →](../how-to/websites-on-ipfs/single-page-website.md).
 
 ## macOS
 
@@ -93,7 +93,8 @@ The IPFS Desktop application has finished installing. You can now start to [add 
 
    ![The IPFS Desktop status bar menu in the macOS status bar.](./images/ipfs-desktop/install-macos-ipfs-desktop-status-bar.png)
 
-The IPFS Desktop application has finished installing. You can now start to [add your site](#add-your-site).
+The IPFS Desktop application has finished installing. Now, learn how to [host a website using IPFS →](../how-to/websites-on-ipfs/single-page-website.md).
+
 
 ## Ubuntu
 


### PR DESCRIPTION
While going through https://docs.ipfs.tech/install/ipfs-desktop/, I noticed two busted links:
1) The link in the last sentence of the Windows install _The IPFS Desktop application has finished installing. You can now start to [add your site](https://docs.ipfs.tech/install/how-to/websites-on-ipfs/single-page-website/#add-your-site)._ returns a 404
2) The link in the last sentence of the Mac install _The IPFS Desktop application has finished installing. You can now start to [add your site](https://docs.ipfs.tech/install/ipfs-desktop/#add-your-site)._ doesn't go anywhere.

I'm guessing they were supposed to go to https://docs.ipfs.tech/how-to/websites-on-ipfs/single-page-website/ so I updated them accordingly. LMK if this is not the case.
