### PR TITLE
Adding filecoin network indexer stuffs

### DIFF
--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -61,13 +61,14 @@ Referring to files by their content, not their location, is one of the most powe
 
 Sharing files between peers is incredibly powerful — and has many nuances! Learn about file-sharing paradigms and tools:
 
-- [Distributed Hash Tables (DHTs)](dht.md)
-- [Merkle DAGs](merkle-dag.md)
 - [Bitswap](bitswap.md)
+- [Distributed Hash Tables (DHTs)](dht.md)
+- [File systems](file-systems.md)
+- [Filecoin network indexer](https://docs.cid.contact/filecoin-network-indexer/overview)
 - [IPLD](ipld.md)
 - [IPNS](ipns.md)
 - [libp2p](libp2p.md)
-- [File systems](file-systems.md)
+- [Merkle DAGs](merkle-dag.md)
 
 ## Integrating IPFS and the existing Web
 

--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -242,6 +242,11 @@ Information Space is the set of concepts, and relations among them, held by an i
 
 The InterPlanetary Linked Data (IPLD) model is a set of specifications in support of decentralized data structures for the content-addressable web. Key features are interoperable protocols, easily upgradeable, backward compatible. A single namespace for all hash-based protocols. [More about IPLD](https://ipld.io/)
 
+### IPNI
+
+The InterPlanetary Network Indexer (IPNI). Reference: https://github.com/ipni
+Lorem ipsum, this is just a placeholder for now.
+
 ### IPNS
 
 The InterPlanetary Name System (IPNS) is a system for creating and updating mutable links to IPFS content. IPNS allows for publishing the latest version of any IPFS content, even though the underlying IPFS hash has changed. [More about IPNS](ipns.md)


### PR DESCRIPTION
In reference to issue #1296.

- Adding in placeholders and whatnot, mostly so I don't forget about this.
- There's also potential for a new page to be added to the docs to cover the Filecoin network indexer.
- Links to the reference material are absolute links at the moment, will change to relative links when there is relative content to link to.
- Also alphabetized the list under the **peer to peer file sharing** sub-header on the concepts landing page.
