### PR TITLE
Add Markdownlint Github action 

### DIFF
--- a/.github/workflows/markdownlint-action.yml
+++ b/.github/workflows/markdownlint-action.yml
@@ -1,0 +1,14 @@
+name: markdownlint check
+
+on: [pull_request]
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: markdownlint-cli
+        uses: nosborn/github-action-markdown-cli@v3.2.0
+        with:
+          files: .
+          config_file: .markdownlint.jsonc
+      

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,273 @@
+{
+  // Example markdownlint JSON(C) configuration with all properties set to their default value
+
+  // Default state for all rules
+  "default": true,
+
+  // Path to configuration file to extend
+  "extends": null,
+
+  // MD001/heading-increment/header-increment - Heading levels should only increment by one level at a time
+  "MD001": true,
+
+  // MD003/heading-style/header-style - Heading style
+  "MD003": {
+    // Heading style
+    "style": "atx"
+  },
+
+  // MD004/ul-style - Unordered list style
+  "MD004": {
+    // List style
+    "style": "dash"
+  },
+
+  // MD005/list-indent - Inconsistent indentation for list items at the same level
+  "MD005": true,
+
+  // MD007/ul-indent - Unordered list indentation
+  "MD007": {
+    // Spaces for indent
+    "indent": 2,
+    // Whether to indent the first level of the list
+    "start_indented": false,
+    // Spaces for first level indent (when start_indented is set)
+    "start_indent": 2
+  },
+
+  // MD009/no-trailing-spaces - Trailing spaces
+  "MD009": {
+    // Spaces for line break
+    "br_spaces": 2,
+    // Allow spaces for empty lines in list items
+    "list_item_empty_lines": false,
+    // Include unnecessary breaks
+    "strict": false
+  },
+
+  // MD010/no-hard-tabs - Hard tabs
+  "MD010": false,
+
+  // MD011/no-reversed-links - Reversed link syntax
+  "MD011": true,
+
+  // MD012/no-multiple-blanks - Multiple consecutive blank lines
+  "MD012": true,
+
+  // MD013/line-length - Line length
+  "MD013": {
+    // Number of characters
+    "line_length": 80,
+    // Number of characters for headings
+    "heading_line_length": 80,
+    // Number of characters for code blocks
+    "code_block_line_length": 80,
+    // Include code blocks
+    "code_blocks": true,
+    // Include tables
+    "tables": true,
+    // Include headings
+    "headings": true,
+    // Include headings
+    "headers": true,
+    // Strict length checking
+    "strict": false,
+    // Stern length checking
+    "stern": false
+  },
+
+  // MD014/commands-show-output - Dollar signs used before commands without showing output
+  "MD014": true,
+
+  // MD018/no-missing-space-atx - No space after hash on atx style heading
+  "MD018": true,
+
+  // MD019/no-multiple-space-atx - Multiple spaces after hash on atx style heading
+  "MD019": true,
+
+  // MD020/no-missing-space-closed-atx - No space inside hashes on closed atx style heading
+  "MD020": false,
+
+  // MD021/no-multiple-space-closed-atx - Multiple spaces inside hashes on closed atx style heading
+  "MD021": false,
+
+  // MD022/blanks-around-headings/blanks-around-headers - Headings should be surrounded by blank lines
+  "MD022": {
+    // Blank lines above heading
+    "lines_above": 1,
+    // Blank lines below heading
+    "lines_below": 1
+  },
+
+  // MD023/heading-start-left/header-start-left - Headings must start at the beginning of the line
+  "MD023": true,
+
+  // MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
+  "MD024": {
+    // Only check sibling headings
+    "allow_different_nesting": false,
+    // Only check sibling headings
+    "siblings_only": true
+  },
+
+  // MD025/single-title/single-h1 - Multiple top-level headings in the same document
+  "MD025": {
+    // Heading level
+    "level": 1,
+    // RegExp for matching title in front matter
+    "front_matter_title": ""
+  },
+
+  // MD026/no-trailing-punctuation - Trailing punctuation in heading
+  "MD026": {
+    // Punctuation characters
+    "punctuation": ".,;:!。，；：！"
+  },
+
+  // MD027/no-multiple-space-blockquote - Multiple spaces after blockquote symbol
+  "MD027": true,
+
+  // MD028/no-blanks-blockquote - Blank line inside blockquote
+  "MD028": true,
+
+  // MD029/ol-prefix - Ordered list item prefix
+  "MD029": {
+    // List style
+    "style": "one"
+  },
+
+  // MD030/list-marker-space - Spaces after list markers
+  "MD030": {
+    // Spaces for single-line unordered list items
+    "ul_single": 1,
+    // Spaces for single-line ordered list items
+    "ol_single": 1,
+    // Spaces for multi-line unordered list items
+    "ul_multi": 1,
+    // Spaces for multi-line ordered list items
+    "ol_multi": 1
+  },
+
+  // MD031/blanks-around-fences - Fenced code blocks should be surrounded by blank lines
+  "MD031": {
+    // Include list items
+    "list_items": true
+  },
+
+  // MD032/blanks-around-lists - Lists should be surrounded by blank lines
+  "MD032": true,
+
+  // MD033/no-inline-html - Inline HTML
+  "MD033": {
+    // Allowed elements
+    "allowed_elements": []
+  },
+
+  // MD034/no-bare-urls - Bare URL used
+  // TODO remove all bare URLS from docs
+  // We should not have bare urls in the docs
+  // Once done, set this to true
+  "MD034": false,
+
+  // MD035/hr-style - Horizontal rule style
+  "MD035": {
+    // Horizontal rule style
+    "style": "consistent"
+  },
+
+  // MD036/no-emphasis-as-heading/no-emphasis-as-header - Emphasis used instead of a heading
+  "MD036": {
+    // Punctuation characters
+    "punctuation": ".,;:!?。，；：！？"
+  },
+
+  // MD037/no-space-in-emphasis - Spaces inside emphasis markers
+  "MD037": true,
+
+  // MD038/no-space-in-code - Spaces inside code span elements
+  "MD038": true,
+
+  // MD039/no-space-in-links - Spaces inside link text
+  "MD039": true,
+
+  // MD040/fenced-code-language - Fenced code blocks should have a language specified
+  "MD040": true,
+
+  // MD041/first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+  "MD041": {
+    // Heading level
+    "level": 1,
+    // RegExp for matching title in front matter
+    "front_matter_title": "^\\s*title\\s*[:=]"
+  },
+
+  // MD042/no-empty-links - No empty links
+  "MD042": true,
+
+  // MD043/required-headings/required-headers - Required heading structure
+  // TODO 
+  // We may want to utilize this rule, not sure what the struct would be
+  "MD043": {
+    // List of headings
+    "headings": [],
+    // List of headings
+    "headers": []
+  },
+
+  // MD044/proper-names - Proper names should have the correct capitalization
+  // TODO
+  // Determine if we want to use this, 
+  // May cause issues
+  "MD044": {
+    // List of proper names
+    "names": [],
+    // Include code blocks
+    "code_blocks": true,
+    // Include HTML elements
+    "html_elements": true
+  },
+
+  // MD045/no-alt-text - Images should have alternate text (alt text)
+  "MD045": true,
+
+  // MD046/code-block-style - Code block style
+  "MD046": {
+    // Block style
+    "style": "fenced"
+  },
+
+  // MD047/single-trailing-newline - Files should end with a single newline character
+  "MD047": true,
+
+  // MD048/code-fence-style - Code fence style
+  "MD048": {
+    // Code fence style
+    "style": "backtick"
+  },
+
+  // MD049/emphasis-style - Emphasis style should be consistent
+  "MD049": {
+    // Emphasis style should be consistent
+    "style": "underscore"
+  },
+
+  // MD050/strong-style - Strong style should be consistent
+  "MD050": {
+    // Strong style should be consistent
+    "style": "asterisk"
+  },
+
+  // MD051/link-fragments - Link fragments should be valid
+  "MD051": true,
+
+  // MD052/reference-links-images - Reference links and images should use a label that is defined
+  "MD052": true,
+
+  // MD053/link-image-reference-definitions - Link and image reference definitions should be needed
+  "MD053": {
+    // Ignored definitions
+    "ignored_definitions": [
+      "//"
+    ]
+  }
+}

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -2,7 +2,7 @@
   // Example markdownlint JSON(C) configuration with all properties set to their default value
 
   // Default state for all rules
-  "default": true,
+  "default": false,
 
   // Path to configuration file to extend
   "extends": null,

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -8,24 +8,33 @@
   "extends": null,
 
   // MD001/heading-increment/header-increment - Heading levels should only increment by one level at a time
+  // Enforces bullet 1 of https://docs.ipfs.tech/community/contribute/grammar-formatting-and-style/#titles
   "MD001": true,
 
   // MD003/heading-style/header-style - Heading style
+  // Pretty sure we do this implicitly
+  // Enforces a heading style like the following
+  //
+  // # Title
+  // ## Subheading
   "MD003": {
     // Heading style
     "style": "atx"
   },
 
   // MD004/ul-style - Unordered list style
+  // Enforces https://docs.ipfs.tech/community/contribute/grammar-formatting-and-style/#unordered-lists
   "MD004": {
     // List style
     "style": "dash"
   },
 
   // MD005/list-indent - Inconsistent indentation for list items at the same level
+  // Seems implicitly related to https://docs.ipfs.tech/community/contribute/grammar-formatting-and-style/#unordered-lists
   "MD005": true,
 
   // MD007/ul-indent - Unordered list indentation
+  // Pretty sure we enforce 2 spaces indnetation
   "MD007": {
     // Spaces for indent
     "indent": 2,
@@ -36,6 +45,7 @@
   },
 
   // MD009/no-trailing-spaces - Trailing spaces
+  // Seems like something good to have
   "MD009": {
     // Spaces for line break
     "br_spaces": 2,
@@ -46,15 +56,19 @@
   },
 
   // MD010/no-hard-tabs - Hard tabs
+  // Not sure if we want to enforce this, seems like it would be a good idea?
   "MD010": false,
 
   // MD011/no-reversed-links - Reversed link syntax
+  // Seems obvious, probably good to enforce
   "MD011": true,
 
   // MD012/no-multiple-blanks - Multiple consecutive blank lines
+  // Seems obvious, probably good to enforce
   "MD012": true,
 
   // MD013/line-length - Line length
+  // Very much unsure on this one
   "MD013": {
     // Number of characters
     "line_length": 80,
@@ -77,21 +91,27 @@
   },
 
   // MD014/commands-show-output - Dollar signs used before commands without showing output
+  // Seems obvious, probably good to enforce
   "MD014": true,
 
   // MD018/no-missing-space-atx - No space after hash on atx style heading
+  // Seems to be something we already do anyways
   "MD018": true,
 
   // MD019/no-multiple-space-atx - Multiple spaces after hash on atx style heading
+  // Seems to be something we already do anyways
   "MD019": true,
 
   // MD020/no-missing-space-closed-atx - No space inside hashes on closed atx style heading
+  // Seems irrelvant since we are using atxc headings
   "MD020": false,
 
   // MD021/no-multiple-space-closed-atx - Multiple spaces inside hashes on closed atx style heading
+  // Seems irrelvant since we are using atxc headings
   "MD021": false,
 
   // MD022/blanks-around-headings/blanks-around-headers - Headings should be surrounded by blank lines
+  // Seems to be something we already do anyways
   "MD022": {
     // Blank lines above heading
     "lines_above": 1,
@@ -100,43 +120,54 @@
   },
 
   // MD023/heading-start-left/header-start-left - Headings must start at the beginning of the line
+  // Seems to be something we already do anyways
   "MD023": true,
 
   // MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
+  // Seems to be a good practice 
   "MD024": {
     // Only check sibling headings
-    "allow_different_nesting": false,
-    // Only check sibling headings
+    // Added this in case we start doing changelogs
     "siblings_only": true
   },
 
   // MD025/single-title/single-h1 - Multiple top-level headings in the same document
+  // Enforces bullet 2 of https://docs.ipfs.tech/community/contribute/grammar-formatting-and-style/#titles
   "MD025": {
     // Heading level
     "level": 1,
     // RegExp for matching title in front matter
-    "front_matter_title": ""
+    "front_matter_title": "^\\s*title\\s*[:=]"
   },
 
   // MD026/no-trailing-punctuation - Trailing punctuation in heading
+  // Enforces bullet 3 of https://docs.ipfs.tech/community/contribute/grammar-formatting-and-style/#titles
   "MD026": {
     // Punctuation characters
     "punctuation": ".,;:!。，；：！"
   },
 
   // MD027/no-multiple-space-blockquote - Multiple spaces after blockquote symbol
+  // Seems like a good practice
   "MD027": true,
 
   // MD028/no-blanks-blockquote - Blank line inside blockquote
+  // Seems like a good practice
   "MD028": true,
 
   // MD029/ol-prefix - Ordered list item prefix
+  // Pretty sure we enforce this without calling it out
+  //
+  // 1.
+  // 1.
+  // 1.
   "MD029": {
     // List style
     "style": "one"
   },
 
   // MD030/list-marker-space - Spaces after list markers
+  // Seems like we already do this
   "MD030": {
     // Spaces for single-line unordered list items
     "ul_single": 1,
@@ -149,51 +180,63 @@
   },
 
   // MD031/blanks-around-fences - Fenced code blocks should be surrounded by blank lines
+  // Seems like a good practice / we already do this
   "MD031": {
     // Include list items
     "list_items": true
   },
 
   // MD032/blanks-around-lists - Lists should be surrounded by blank lines
+  // Seems like a good practice / we already do this
   "MD032": true,
 
   // MD033/no-inline-html - Inline HTML
+  // Not sure about this one - do we need to allow any html elements?
+
   "MD033": {
     // Allowed elements
     "allowed_elements": []
   },
 
   // MD034/no-bare-urls - Bare URL used
+  // Pretty sure we don't enforce this, but I think it would be a good idea
   // TODO remove all bare URLS from docs
   // We should not have bare urls in the docs
   // Once done, set this to true
   "MD034": false,
 
   // MD035/hr-style - Horizontal rule style
+  // Not sure if this matters
   "MD035": {
     // Horizontal rule style
     "style": "consistent"
   },
 
   // MD036/no-emphasis-as-heading/no-emphasis-as-header - Emphasis used instead of a heading
+  // Seems like a good rule to have in place
   "MD036": {
     // Punctuation characters
     "punctuation": ".,;:!?。，；：！？"
   },
 
   // MD037/no-space-in-emphasis - Spaces inside emphasis markers
+  // Seems like a good rule to have in place
   "MD037": true,
 
   // MD038/no-space-in-code - Spaces inside code span elements
+  // Seems like a good rule to have in place
   "MD038": true,
 
   // MD039/no-space-in-links - Spaces inside link text
+  // Seems like a good rule to have in place
   "MD039": true,
 
   // MD040/fenced-code-language - Fenced code blocks should have a language specified
+  // Seems like we already do this
   "MD040": true,
 
   // MD041/first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+  // Enforces https://docs.ipfs.tech/community/contribute/grammar-formatting-and-style/#titles
   "MD041": {
     // Heading level
     "level": 1,
@@ -202,6 +245,7 @@
   },
 
   // MD042/no-empty-links - No empty links
+  // Seems like a good rule to have in place
   "MD042": true,
 
   // MD043/required-headings/required-headers - Required heading structure
@@ -217,47 +261,55 @@
   // MD044/proper-names - Proper names should have the correct capitalization
   // TODO
   // Determine if we want to use this, 
+  // Could be use for things like JavaScript, Python, LibP2P, etc.
   // May cause issues
   "MD044": {
     // List of proper names
     "names": [],
     // Include code blocks
-    "code_blocks": true,
+    "code_blocks": false,
     // Include HTML elements
-    "html_elements": true
+    "html_elements": false
   },
 
   // MD045/no-alt-text - Images should have alternate text (alt text)
+  // Enforces https://docs.ipfs.tech/community/contribute/grammar-formatting-and-style/#alt-text
   "MD045": true,
 
   // MD046/code-block-style - Code block style
+  // Seems like we already enforce this
   "MD046": {
     // Block style
     "style": "fenced"
   },
 
   // MD047/single-trailing-newline - Files should end with a single newline character
+  // Not sure if we enforce this, but seems like a good practice
   "MD047": true,
 
   // MD048/code-fence-style - Code fence style
+  // Seems like we already enforce this
   "MD048": {
     // Code fence style
     "style": "backtick"
   },
 
   // MD049/emphasis-style - Emphasis style should be consistent
+  // Enforces https://docs.ipfs.tech/community/contribute/grammar-formatting-and-style/#italics
   "MD049": {
     // Emphasis style should be consistent
     "style": "underscore"
   },
 
   // MD050/strong-style - Strong style should be consistent
+  // Enforces https://docs.ipfs.tech/community/contribute/grammar-formatting-and-style/#bold-text
   "MD050": {
     // Strong style should be consistent
     "style": "asterisk"
   },
 
   // MD051/link-fragments - Link fragments should be valid
+  // Seems like a good rule, markdow-link-check should also catch this
   "MD051": true,
 
   // MD052/reference-links-images - Reference links and images should use a label that is defined


### PR DESCRIPTION
For the initial implementation, tried to configure the rules  to match https://docs.ipfs.tech/community/contribute/grammar-formatting-and-style/#style.

Rule definitions and descriptions are [here](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md)

The rule configuration is defined in `.markdownlint.jsonc`. Each rule has comments that describe whether or not it's already in the style guide / it's something we already enforce without defining it in the style guide / if it might be a good rule to enforce

**Todo:**
- Determine what other configurations the `markdownlint-action.yml `file should have
- Check that the config (`.markdownlint.jsonc`) actually matches https://docs.ipfs.tech/community/contribute/grammar-formatting-and-style/#style
- Run tests for each rule to make sure that the markdownlint check catches violations / doesn't produce false results
- For rules that ARE NOT defined in https://docs.ipfs.tech/community/contribute/grammar-formatting-and-style/#style, determine if we actually want these rules and, if we do, ensure that they won't cause problems for writers