### PR TITLE
chore: add resolver script

### DIFF
--- a/.github/workflows/check-cids-paths.yml
+++ b/.github/workflows/check-cids-paths.yml
@@ -5,8 +5,6 @@ on:
     paths:
       - '**/*.md'
       - '**/*.txt'
-  schedule:
-    - cron: '0 0 * * 0'
 
 jobs:
   check-and-resolve:

--- a/.github/workflows/check-cids-paths.yml
+++ b/.github/workflows/check-cids-paths.yml
@@ -2,6 +2,7 @@ name: IPFS Resolver
 
 on:
   pull_request:
+    branches: [ main ]
     paths:
       - '**/*.md'
       - '**/*.txt'

--- a/.github/workflows/check-cids-paths.yml
+++ b/.github/workflows/check-cids-paths.yml
@@ -1,0 +1,66 @@
+name: IPFS Resolver
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '**/*.txt'
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  check-and-resolve:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check for CIDs, paths, and DNSLink records
+        run: |
+          # Check for CIDs
+          CIDS=$(grep -rnw '.' -e '^[Qmz]\{1,2}[a-zA-Z0-9]\{44\}$')
+          # Check for content paths
+          PATHS=$(grep -rnw '.' -e '/ipfs/[a-zA-Z0-9]\{46\}')
+          # Check for DNSLink records (excluding .com, .net, and .org)
+          DNSLINKS=$(grep -rnw '.' -e '/ipns/[^(.com|.net|.org)]')
+      - name: Validate and resolve CIDs, paths, and DNSLink records
+        run: |
+          # Validate and resolve CIDs
+          for CID in $CIDS; do
+            ipfs resolve $CID
+            if [ $? -eq 0 ]; then
+              echo "$CID is valid and resolves successfully"
+            else
+              echo "$CID is invalid or does not resolve successfully"
+            fi
+          done
+          # Validate and resolve content paths
+          for PATH in $PATHS; do
+            ipfs resolve $PATH
+            if [ $? -eq 0 ]; then
+              echo "$PATH is valid and resolves successfully"
+            else
+              echo "$PATH is invalid or does not resolve successfully"
+            fi
+          done
+          # Validate and resolve DNSLink records
+          for DNSLINK in $DNSLINKS; do
+            # Use the `ipfs dns` command to validate DNSLink records
+            ipfs dns $DNSLINK
+            if [ $? -eq 0 ]; then
+              echo "$DNSLINK is valid and resolves successfully"
+            else
+              echo "$DNSLINK is invalid or does not resolve successfully"
+            fi
+          done
+      - name: Check for URIs
+        run: |
+          # Check for URIs
+          URIS=$(grep -rnw '.' -e 'ipfs://[a-zA-Z0-9]\{46\}')
+          # Validate and resolve URIs
+          for URI in $URIS; do
+            ipfs resolve $URI
+            if [ $? -eq 0 ]; then
+              echo "$URI is valid and resolves successfully"
+            else
+              echo "$URI is invalid or does not resolve successfully"
+            fi
+          done


### PR DESCRIPTION
## Context

- As part of the recent efforts to add a range of lint-based checkers, I was playing around with this to create a script based on what is mentioned in the linked issue.
- Adds a CI job that checks if CIDs, URIs and content paths resolve by using regular expressions to find each type and then attempts to resolve with IPFS.
- resolves #777