### PR TITLE
Add warning about js-ipfs being discontinued / point to Helia in a few places

### DIFF
--- a/docs/concepts/ipfs-implementations.md
+++ b/docs/concepts/ipfs-implementations.md
@@ -5,6 +5,13 @@ description: "There isn't just one canonical IPFS implementation. Learn about th
 
 # IPFS Implementations
 
+:::warning js-ipfs being discontinued
+Development of the [js-ipfs project](https://github.com/ipfs/js-ipfs) is being discontinued to focus on [Helia](https://github.com/ipfs/helia), a leaner, more modular, modern implementation of IPFS in JavaScript slated for release in 2023. To learn more about Helia and the current state of IPFS in JS, see the [blog post](https://blog.ipfs.tech/state-of-ipfs-in-js/). 
+
+Because of this, js-ipfs tutorials may be out of date, and will eventually be archived.
+
+:::
+
 There isn't one canonical IPFS implementation. There is so much to explore in this space that it's ideal to have a plethora of implementations experimenting and optimizing for various usecases. Below is a list of IPFS implementations that we know of in name alphabetical order. If you're aware of more, please add!
 
 ::: tip

--- a/docs/concepts/ipfs-implementations.md
+++ b/docs/concepts/ipfs-implementations.md
@@ -5,13 +5,6 @@ description: "There isn't just one canonical IPFS implementation. Learn about th
 
 # IPFS Implementations
 
-:::warning js-ipfs being discontinued
-Development of the [js-ipfs project](https://github.com/ipfs/js-ipfs) is being discontinued to focus on [Helia](https://github.com/ipfs/helia), a leaner, more modular, modern implementation of IPFS in JavaScript slated for release in 2023. To learn more about Helia and the current state of IPFS in JS, see the [blog post](https://blog.ipfs.tech/state-of-ipfs-in-js/). 
-
-Because of this, js-ipfs tutorials may be out of date, and will eventually be archived.
-
-:::
-
 There isn't one canonical IPFS implementation. There is so much to explore in this space that it's ideal to have a plethora of implementations experimenting and optimizing for various usecases. Below is a list of IPFS implementations that we know of in name alphabetical order. If you're aware of more, please add!
 
 ::: tip
@@ -35,10 +28,18 @@ Relevant specifications are listed in [ipfs/specs](https://github.com/ipfs/specs
 | ipfs-nucleus     | <https://github.com/peergos/ipfs-nucleus/>                              | go                     | Minimal IPFS replacement for P2P IPLD apps.                                                                              |
 | ipget            | <https://github.com/ipfs/ipget>                                         | go                     | Minimal wget insipired tool to download files from IPFS nodes over bitswap.                                              |
 | iroh             | <https://github.com/n0-computer/iroh>                                   | rust                   | Extreme-Efficiency oriented IPFS implementation.                                                                         |
-| js-ipfs          | <https://github.com/ipfs/js-ipfs>                                       | javascript, typescript | Javascript implementation targeting nodejs and browsers.                                                                 |
+| js-ipfs          | <https://github.com/ipfs/js-ipfs>                                       | javascript, typescript | Javascript implementation targeting nodejs and browsers.  [**Development of js-ipfs is being discontinued**](#js-ipfs-being-discontinued).                                                                |
 | Kubo             | <https://github.com/ipfs/kubo>                                          | go                     | Generalist daemon oriented IPFS implementation with an extensive HTTP API.                                               |
 | Linux2ipfs       | <https://github.com/Jorropo/linux2ipfs>                                 | go                     | Small pipeline and extreme-performance oriented implementation to upload files and deltas to pinning services very fast. |
 | Lotus            | <https://github.com/filecoin-project/lotus>                             | go                     | Filecoin node handling consensus, storage providing, making storage deals, importing data, ...                           |
 | py-ipfs          | <https://github.com/ipfs-shipyard/py-ipfs>                              | python                 | Python IPFS implementation.                                                                                              |
 | rust-ipfs        | <https://github.com/rs-ipfs/rust-ipfs>                                  | rust                   | Rust IPFS implementation.                                                                                                |
 | whypfs           | <https://github.com/whyrusleeping/whypfs>                               | go                     | Daemon based on the same building blocks as Kubo but with some options tweaking for more performance.                    |
+
+:::warning 
+### js-ipfs being discontinued
+Development of the [js-ipfs project](https://github.com/ipfs/js-ipfs) is being discontinued to focus on [Helia](https://github.com/ipfs/helia), a leaner, more modular, modern implementation of IPFS in JavaScript scheduled for release in 2023. To learn more about Helia and the current state of IPFS in JS, see the [blog post](https://blog.ipfs.tech/state-of-ipfs-in-js/). 
+
+Because of this, js-ipfs tutorials may be out of date, and will eventually be archived.
+
+:::

--- a/docs/concepts/nodes.md
+++ b/docs/concepts/nodes.md
@@ -120,6 +120,14 @@ See [Working with Go](../reference/go/api.md#working-with-go) and [CLI Quick Sta
 
 ### JS-IPFS
 
+:::warning 
+### js-ipfs being discontinued
+Development of the [js-ipfs project](https://github.com/ipfs/js-ipfs) is being discontinued to focus on [Helia](https://github.com/ipfs/helia), a leaner, more modular, modern implementation of IPFS in JavaScript scheduled for release in 2023. To learn more about Helia and the current state of IPFS in JS, see the [blog post](https://blog.ipfs.tech/state-of-ipfs-in-js/). 
+
+Because of this, js-ipfs tutorials may be out of date, and will eventually be archived.
+
+:::
+
 An implementation of IPFS written entirely in JavaScript. It runs in a browser, a Service Worker, Electron and Node.js. Capabilities depend on the runtime.
 
 More at [js.ipfs.io](https://js.ipfs.io) and [Github](https://github.com/ipfs/js-ipfs#readme).

--- a/docs/how-to/create-simple-chat-app.md
+++ b/docs/how-to/create-simple-chat-app.md
@@ -5,6 +5,13 @@ description: "Learn how to deploy a minimal chat app entirely in the browser usi
 
 # Create a simple chat app
 
+:::warning js-ipfs being discontinued
+Development of the [js-ipfs project](https://github.com/ipfs/js-ipfs) is being discontinued to focus on [Helia](https://github.com/ipfs/helia), a leaner, more modular, modern implementation of IPFS in JavaScript slated for release in 2023. To learn more about Helia and the current state of IPFS in JS, see the [blog post](https://blog.ipfs.tech/state-of-ipfs-in-js/). 
+
+Because of this, js-ipfs tutorials may be out of date, and will eventually be archived.
+
+:::
+
 This how-to demonstrates a minimal chat app in [js-ipfs](../reference/js/api.md#js-ipfs) entirely in the browser.
 
 Here’s a quick demo of the app:

--- a/docs/how-to/create-simple-chat-app.md
+++ b/docs/how-to/create-simple-chat-app.md
@@ -5,8 +5,9 @@ description: "Learn how to deploy a minimal chat app entirely in the browser usi
 
 # Create a simple chat app
 
-:::warning js-ipfs being discontinued
-Development of the [js-ipfs project](https://github.com/ipfs/js-ipfs) is being discontinued to focus on [Helia](https://github.com/ipfs/helia), a leaner, more modular, modern implementation of IPFS in JavaScript slated for release in 2023. To learn more about Helia and the current state of IPFS in JS, see the [blog post](https://blog.ipfs.tech/state-of-ipfs-in-js/). 
+:::warning 
+### js-ipfs being discontinued
+Development of the [js-ipfs project](https://github.com/ipfs/js-ipfs) is being discontinued to focus on [Helia](https://github.com/ipfs/helia), a leaner, more modular, modern implementation of IPFS in JavaScript scheduled for release in 2023. To learn more about Helia and the current state of IPFS in JS, see the [blog post](https://blog.ipfs.tech/state-of-ipfs-in-js/). 
 
 Because of this, js-ipfs tutorials may be out of date, and will eventually be archived.
 

--- a/docs/install/js-ipfs.md
+++ b/docs/install/js-ipfs.md
@@ -5,8 +5,9 @@ description: "A simple walkthrough of how to perform basic IPFS operations using
 
 # Install IPFS for JavaScript (js-ipfs)
 
-:::warning js-ipfs being discontinued
-Development of the [js-ipfs project](https://github.com/ipfs/js-ipfs) is being discontinued to focus on [Helia](https://github.com/ipfs/helia), a leaner, more modular, modern implementation of IPFS in JavaScript slated for release in 2023. To learn more about Helia and the current state of IPFS in JS, see the [blog post](https://blog.ipfs.tech/state-of-ipfs-in-js/). 
+:::warning 
+### js-ipfs being discontinued
+Development of the [js-ipfs project](https://github.com/ipfs/js-ipfs) is being discontinued to focus on [Helia](https://github.com/ipfs/helia), a leaner, more modular, modern implementation of IPFS in JavaScript scheduled for release in 2023. To learn more about Helia and the current state of IPFS in JS, see the [blog post](https://blog.ipfs.tech/state-of-ipfs-in-js/). 
 
 Because of this, js-ipfs tutorials may be out of date, and will eventually be archived.
 

--- a/docs/install/js-ipfs.md
+++ b/docs/install/js-ipfs.md
@@ -5,6 +5,13 @@ description: "A simple walkthrough of how to perform basic IPFS operations using
 
 # Install IPFS for JavaScript (js-ipfs)
 
+:::warning js-ipfs being discontinued
+Development of the [js-ipfs project](https://github.com/ipfs/js-ipfs) is being discontinued to focus on [Helia](https://github.com/ipfs/helia), a leaner, more modular, modern implementation of IPFS in JavaScript slated for release in 2023. To learn more about Helia and the current state of IPFS in JS, see the [blog post](https://blog.ipfs.tech/state-of-ipfs-in-js/). 
+
+Because of this, js-ipfs tutorials may be out of date, and will eventually be archived.
+
+:::
+
 This guide will walk you through the basics of using JS-IPFS, an implementation of IPFS in JavaScript. JS-IPFS is one of multiple [IPFS implementations](../concepts/ipfs-implementations.md). You will learn how to install and spawn a node using the available libraries, and add, retrieve, read, and remove files. If you are unsure about the meaning of some terms, check out the [glossary](../concepts/glossary.md).
 
 ::: tip Environment

--- a/docs/project/repository-guide.md
+++ b/docs/project/repository-guide.md
@@ -18,8 +18,9 @@ Organization and repository links for the top-level projects shipped as part of 
 
 ### Protocol implementations
 
-:::warning js-ipfs being discontinued
-Development of the [js-ipfs project](https://github.com/ipfs/js-ipfs) is being discontinued to focus on [Helia](https://github.com/ipfs/helia), a leaner, more modular, modern implementation of IPFS in JavaScript slated for release in 2023. To learn more about Helia and the current state of IPFS in JS, see the [blog post](https://blog.ipfs.tech/state-of-ipfs-in-js/). 
+:::warning 
+### js-ipfs being discontinued
+Development of the [js-ipfs project](https://github.com/ipfs/js-ipfs) is being discontinued to focus on [Helia](https://github.com/ipfs/helia), a leaner, more modular, modern implementation of IPFS in JavaScript scheduled for release in 2023. To learn more about Helia and the current state of IPFS in JS, see the [blog post](https://blog.ipfs.tech/state-of-ipfs-in-js/). 
 
 Because of this, js-ipfs tutorials may be out of date, and will eventually be archived.
 

--- a/docs/project/repository-guide.md
+++ b/docs/project/repository-guide.md
@@ -18,6 +18,13 @@ Organization and repository links for the top-level projects shipped as part of 
 
 ### Protocol implementations
 
+:::warning js-ipfs being discontinued
+Development of the [js-ipfs project](https://github.com/ipfs/js-ipfs) is being discontinued to focus on [Helia](https://github.com/ipfs/helia), a leaner, more modular, modern implementation of IPFS in JavaScript slated for release in 2023. To learn more about Helia and the current state of IPFS in JS, see the [blog post](https://blog.ipfs.tech/state-of-ipfs-in-js/). 
+
+Because of this, js-ipfs tutorials may be out of date, and will eventually be archived.
+
+:::
+
 - [Kubo](https://github.com/ipfs/kubo): The reference implementation written in Go.
 - [js-ipfs](https://github.com/ipfs/js-ipfs): The JavaScript implementation of IPFS.
 - [rust-ipfs](https://github.com/rs-ipfs/rust-ipfs): Alpha implementation in Rust.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -33,6 +33,14 @@ Use it as:
 
 ### JavaScript (js-ipfs)
 
+:::warning 
+### js-ipfs being discontinued
+Development of the [js-ipfs project](https://github.com/ipfs/js-ipfs) is being discontinued to focus on [Helia](https://github.com/ipfs/helia), a leaner, more modular, modern implementation of IPFS in JavaScript scheduled for release in 2023. To learn more about Helia and the current state of IPFS in JS, see the [blog post](https://blog.ipfs.tech/state-of-ipfs-in-js/). 
+
+Because of this, js-ipfs tutorials may be out of date, and will eventually be archived.
+
+:::
+
 [API resources for js-ipfs](js/api.md), including the JS core API reference and the JS HTTP client library.
 
 Explore the Mutable File System, Regular Files API, and DAG API through ProtoSchool's [coding challenges](https://proto.school/course/ipfs).

--- a/docs/reference/js/api.md
+++ b/docs/reference/js/api.md
@@ -14,6 +14,14 @@ There are three main JavaScript libraries for working with IPFS in JavaScript: `
 
 ### JS-IPFS
 
+:::warning 
+### js-ipfs being discontinued
+Development of the [js-ipfs project](https://github.com/ipfs/js-ipfs) is being discontinued to focus on [Helia](https://github.com/ipfs/helia), a leaner, more modular, modern implementation of IPFS in JavaScript scheduled for release in 2023. To learn more about Helia and the current state of IPFS in JS, see the [blog post](https://blog.ipfs.tech/state-of-ipfs-in-js/). 
+
+Because of this, js-ipfs tutorials may be out of date, and will eventually be archived.
+
+:::
+
 [JS-IPFS](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs) is a full implementation of IPFS, similar to [Kubo (Go-IPFS)](https://github.com/ipfs/kubo). You can use it either as a command-line application or as a library to start an IPFS node directly in your program, as JS implementation is available as two Node.js packages, `ipfs-core` and `ipfs`.
 
 - [ipfs-core](https://www.npmjs.com/package/ipfs-core) includes the core IPFS API and is intended to be used to run an IPFS node as part of your application without the need to start external processes or manage API ports and servers.


### PR DESCRIPTION
# Describe your changes
Addresses https://github.com/ipfs/ipfs-docs/issues/1465 and [Part 1 of issue 1459](https://github.com/ipfs/ipfs-docs/issues/1459#issuecomment-1409131076)

## Checklist before requesting a review
- [ ] Passing the beta version of the **Check Markdown links for modified files** check. Action results can be viewed [here](https://github.com/ipfs/ipfs-docs/actions/workflows/action.yml).

## Checklist before merging
- [ ] Passing all required checks (The beta **Check Markdown links for modified files** check is not required)
