### PR TITLE
Add helia to ignored words

### DIFF
--- a/.github/styles/pln-ignore.txt
+++ b/.github/styles/pln-ignore.txt
@@ -94,6 +94,7 @@ GUIs
 Hackathon
 hackathons
 Hareesh
+Helia
 homebrew
 hostname
 HTML


### PR DESCRIPTION
## Background

We're getting a lot of spelling errors from the Vale GitHub action that does spell checks for `Helia`.

For example: https://github.com/ipfs/ipfs-docs/pull/1466/files#diff-ae2431aa520d47f48cd21d80f551e44f37dc9758528b68a572a4fefa025f95a4R41

## What this PR does

Adds the word Helia to the list of ignored words by spell checker

