### PR TITLE
Fix minor css word bleed issue in top menu

### DIFF
--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -86,8 +86,16 @@ section.tabs-component-panel::before {
     margin-top: -10em;
 }
 
-.nav-links{
-    margin-right: 10%;
-	margin-left: 10%;
-	float: left;
+@media (min-width: 1060px) {
+	.nav-links{
+		margin-right: 10%;
+		margin-left: 10%;
+		float: left;
+	}
+}
+
+@media (min-width: 500px) and (max-width: 720px) {
+	.sidebar{
+		width: 40%;
+	}
 }


### PR DESCRIPTION
# Draft 👉 https://bafybeifv2krof26zoyt24eohlsvz3eyt5mu5dzcx4dn3y5wtspkp3g2epe.on.fleek.co/
Addresses point 3 of https://github.com/ipfs/ipfs-docs/pull/1452#issuecomment-1412494112 -> basically a word bleed issue that occurs on mobile in the top bar menu that should be fixed regardless of the other changes being discussed in 1452 because it's an actual bug. 1452 was incorrectly scoped by me, so splitting work up this way

## Checklist before requesting a review
- [ ] Passing the beta version of the **Check Markdown links for modified files** check. Action results can be viewed [here](https://github.com/ipfs/ipfs-docs/actions/workflows/action.yml).

## Checklist before merging
- [ ] Passing all required checks (The beta **Check Markdown links for modified files** check is not required)
