### PR TITLE
chore: remove line breaks

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -17,9 +17,6 @@ module.exports = {
   markdown: {
     pageSuffix,
     extendMarkdown: md => {
-      md.set({
-        breaks: true
-      })
       md.use(require('markdown-it-video'))
       md.use(require('markdown-it-footnote'))
       md.use(require('markdown-it-task-lists'))
@@ -72,18 +69,18 @@ module.exports = {
           { text: 'Get Started', link: '/install/' },
           { text: 'Concepts', link: '/concepts/' },
           { text: 'Guides', link: '/how-to/' },
-          { text: 'Reference', link: '/reference/' },   
+          { text: 'Reference', link: '/reference/' },
           { text: 'Project', link: '/project/' },
-          { text: 'Case Studies', 
+          { text: 'Case Studies',
             items: [
               {text: 'Arbol', link : '/case-studies/arbol/'},
               {text: 'Audius', link : '/case-studies/audius'},
               {text: 'Fleek', link : '/case-studies/fleek'},
               {text: 'LikeCoin', link : '/case-studies/likecoin'},
               {text: 'Morpheus.Network', link : '/case-studies/morpheus'},
-              {text: 'Snapshot',link : '/case-studies/snapshot'},              
+              {text: 'Snapshot',link : '/case-studies/snapshot'},
             ]
-          }                  
+          }
         ],
 
         sidebar: {
@@ -115,7 +112,7 @@ module.exports = {
                   '/concepts/content-addressing',
                   '/concepts/hashing',
                   '/concepts/immutability',
-                  '/concepts/persistence', 
+                  '/concepts/persistence',
                   '/concepts/privacy-and-encryption',
                   '/concepts/nodes'
               ]
@@ -136,7 +133,7 @@ module.exports = {
                 '/concepts/merkle-dag'
               ]
             },
-            '/concepts/ipfs-implementations', 
+            '/concepts/ipfs-implementations',
             '/concepts/comparisons',
             '/concepts/usage-ideas-examples',
             '/concepts/faq',


### PR DESCRIPTION
## Describe your changes

Removes markdown line breaks so the site doesn't render single newlines as line breaks. This will also allow the markdown syntax to be prettified.

## Files changed

docs/.vuepress/config.js

## What issue(s) does this address?

It was an internal suggestion I passed on that is addressed by this change request.

## Does this update depend on any other PRs?

No

## Checklist before requesting a review
- [ ] Passing the beta version of the **Check Markdown links for modified files** check. Action results can be viewed [here](https://github.com/ipfs/ipfs-docs/actions/workflows/action.yml).

## Checklist before merging
- [ ] Passing all required checks (The beta **Check Markdown links for modified files** check is not required)
