### PR TITLE
windows installation zip file naming issue fixed

### DIFF
--- a/docs/install/command-line.md
+++ b/docs/install/command-line.md
@@ -78,7 +78,7 @@ For installation instructions for your operating system, select the appropriate 
 1. Unzip the file to a sensible location, such as `~\Apps\kubo_v0.18.1`.
 
    ```powershell
-   Expand-Archive -Path kubo_v0.18.1.zip -DestinationPath ~\Apps\kubo_v0.18.1
+   Expand-Archive -Path kubo_v0.18.1_windows-amd64 -DestinationPath ~\Apps\kubo_v0.18.1
    ```
 
 1. Move into the `kubo_v0.18.1` folder


### PR DESCRIPTION
# Describe your changes

The zip file downloaded has 'windows-amd64' in its name, but the name is wrong in unzip command

# Files changed

docs/install/command-line.md

# What issue(s) does this address?

<!-- 
Ideally, your PR should reference an open GitHub issue that it addresses. Add links to any issues that this PR addresses. 
!-->

I have not searched for any issue related to this. Just found it while using the page

# Does this update depend on any other PRs?

<!-- 
Add links to any PRs that this PR depends on. For example, if this is a documentation update describing a new feature that imust be tested and merged before the documentation can be published, link to that PR here
!-->

No

## Checklist before requesting a review
- [x] Passing the beta version of the **Check Markdown links for modified files** check. Action results can be viewed [here](https://github.com/ipfs/ipfs-docs/actions/workflows/action.yml).

## Checklist before merging
- [ ] Passing all required checks (The beta **Check Markdown links for modified files** check is not required)
