### PR TITLE
Removes Algolia from docs.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -26,10 +26,6 @@ module.exports = {
     }
   },
   themeConfig: {
-    algolia: {
-      apiKey: 'e56fc7c611806522df45191e22ed15ac',
-      indexName: 'ipfs-docs'
-    },
     defaultImage: '/images/social-card.png',
     author: {
       name: 'IPFS Team',
@@ -441,6 +437,12 @@ module.exports = {
       {
         type: 'left',
         defaultTitle: ''
+      }
+    ],
+    [
+      '@vuepress/search',
+      {
+        searchMaxSuggestions: 10
       }
     ],
     'vuepress-plugin-chunkload-redirect',

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@vuepress/plugin-google-analytics": "^1.9.8",
         "@vuepress/plugin-html-redirect": "^0.1.4",
         "@vuepress/plugin-last-updated": "^1.9.8",
+        "@vuepress/plugin-search": "^1.9.8",
         "husky": "^8.0.3",
         "lint-staged": "^13.1.1",
         "markdown-it-deflist": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@vuepress/plugin-google-analytics": "^1.9.8",
     "@vuepress/plugin-html-redirect": "^0.1.4",
     "@vuepress/plugin-last-updated": "^1.9.8",
+    "@vuepress/plugin-search": "^1.9.8",
     "husky": "^8.0.3",
     "lint-staged": "^13.1.1",
     "markdown-it-deflist": "^2.1.0",


### PR DESCRIPTION
This is a hotfix PR that reverts the site back to using the default VuePress search. Algolia wasn't indexing the site properly, for some reason. We'll merge this PR while the team figures out what's going on with Algolia.