### PR TITLE
Delete legacy .markdownlint.json

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,0 @@
-{
-  "MD013": false,
-  "MD025": false
-}

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -68,27 +68,7 @@
   "MD012": true,
 
   // MD013/line-length - Line length
-  // Very much unsure on this one
-  "MD013": {
-    // Number of characters
-    "line_length": 80,
-    // Number of characters for headings
-    "heading_line_length": 80,
-    // Number of characters for code blocks
-    "code_block_line_length": 80,
-    // Include code blocks
-    "code_blocks": true,
-    // Include tables
-    "tables": true,
-    // Include headings
-    "headings": true,
-    // Include headings
-    "headers": true,
-    // Strict length checking
-    "strict": false,
-    // Stern length checking
-    "stern": false
-  },
+  "MD013": false,
 
   // MD014/commands-show-output - Dollar signs used before commands without showing output
   // Seems obvious, probably good to enforce


### PR DESCRIPTION
This file is left over from before my tine with PLN - looks like someone was using an older version of the markdownlint tool in the docs. We no longer use this file. The new file is `.markdownlint.jsonc`

