### PR TITLE
Remove/google analytics

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -360,12 +360,6 @@ module.exports = {
     '@vuepress/plugin-back-to-top',
     ['@adamdehaven/vuepress-plugin-custom-tooltip'],
     [
-      '@vuepress/google-analytics',
-      {
-        ga: 'UA-96910779-15'
-      }
-    ],
-    [
       'vuepress-plugin-clean-urls',
       {
         normalSuffix: pageSuffix,

--- a/docs/.vuepress/head.js
+++ b/docs/.vuepress/head.js
@@ -3,7 +3,6 @@ module.exports = [
     'meta',
     { name: 'viewport', content: 'width=device-width, initial-scale=1.0' },
   ],
-  ['link', { rel: 'preconnect', href: 'https://www.google-analytics.com' }],
   [
     'link',
     {


### PR DESCRIPTION
# Describe your changes
Removes Google Analytics from this repo, and thus the IPFS Docs website.


# Files changed
- package.json
- package-lock.json
- /docs/.vuepress/head.js

Pretty sure that's is.

# What issue(s) does this address?

Stops using Google.

# Does this update depend on any other PRs?

No

## Checklist before requesting a review

- [x] Passing the beta version of the **Check Markdown links for modified files** check. Action results can be viewed [here](https://github.com/ipfs/ipfs-docs/actions/workflows/action.yml).

## Checklist before merging
- [x] Passing all required checks (The beta **Check Markdown links for modified files** check is not required)
