### PR TITLE
edit to diagnostic tools

### DIFF
--- a/docs/reference/diagnostic-tools.md
+++ b/docs/reference/diagnostic-tools.md
@@ -38,10 +38,6 @@ The IPFS ecosystem contains various open-source tools for the investigation, dia
 Learn more about CID concepts, including components and versions in the [content addressing concepts guide](../concepts/content-addressing.md).
 :::
 
-## IPFS Gateway Checker
-
-IPFS [Gateway Checker]() provides status information for public IPFS gateways. This information is useful in deciding on which public gateway provider to use, or troubleshooting problems with your current public gateway provider.
-
 ## DAG builder visualiser
 
 [DAG builder visualiser](https://dag.ipfs.tech/) allows you to upload a CAR file and visualize it as a DAG. You can toggle parameters that determine how the DAG will be visualized, such as typ (Balanced, Trickle, Flat) and max amount of children.


### PR DESCRIPTION
@2color this removes the reference to IPFS gateway checker tool due to the unresolved warning banner that pops up every time you go to the site. My thoughts are that we shouldn't be linking users to a site that does this with no explanation. Or, we should at leas texplain this behavior to user so they aren't confused - seems like an option for this PR as well