### PR TITLE
Adds GH action to auto close empty issue

### DIFF
--- a/.github/workflows/close-empty-issue.yml
+++ b/.github/workflows/close-empty-issue.yml
@@ -1,0 +1,24 @@
+name: Close empty issues and templates
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+      - edited
+
+jobs:
+  closeEmptyIssuesAndTemplates:
+    name: Close empty issues and templates
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3 
+    - name: Run empty issues closer action
+      uses: rickstaa/empty-issues-closer-action@v1
+      env:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        close_comment: This issue has been automatically closed because no description was provided. Please provide us with more information to have this issue reopened.
+        open_comment: This issue has been automatically reopened because the author provided more information.
+        check_templates: true
+        template_close_comment: This issue has been automatically closed because no description was provided. Please provide us with more information to have this issue reopened.
+        template_open_comment: This issue has been automatically reopened because the author provided more information.


### PR DESCRIPTION
Adds https://github.com/rickstaa/empty-issues-closer-action to ipfs-docs.

Sidenote: 

I'm not clear on the best way to test GH actions before pushing to prod, so review / input is much appreciated 

Goal:
- Make triage cleaner and easier for docs team
- Automatically close all empty issues with note to author
- Help with spam issues

Todo:
- [ ] Have someone who knows GH Actions review this PR
- [ ] Test
- [ ] Confirm that this does what we want it to do