### PR TITLE
Dependabot updates

### DIFF
--- a/.github/workflows/markdownlint-action.yml
+++ b/.github/workflows/markdownlint-action.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: markdownlint-cli
-        uses: nosborn/github-action-markdown-cli@v3.2.0
+        uses: nosborn/github-action-markdown-cli@v3.3.0
         with:
           files: .
           config_file: .markdownlint.jsonc

--- a/.github/workflows/update-on-new-ipfs-tag.yml
+++ b/.github/workflows/update-on-new-ipfs-tag.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           latest_ipfs_tag: ${{ steps.latest_ipfs.outputs.latest_tag }}
       - name: pull-request
-        uses: repo-sync/pull-request@65785d95a5a466e46a9d0708933a3bd51bbf9dde #v2.6.2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2.12.1
         if: ${{ steps.update.outputs.updated_branch }} # don't create a pr if there was no branch pushed
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- [chore(deps): bump nosborn/github-action-markdown-cli from 3.2.0 to 3.3.0](https://github.com/ipfs/ipfs-docs/commit/8a0c4eff1acfcfaf131b356cae7842873ddca31e)
- [chore(deps): bump repo-sync/pull-request from 2.6.2 to 2.12.1](https://github.com/ipfs/ipfs-docs/commit/2dd47f81027de42381959b4409d29beab9bbec67)