### PR TITLE
fix: :wastebasket: Deprecation notice for js-ipfs

### DIFF
--- a/docs/how-to/companion-node-types.md
+++ b/docs/how-to/companion-node-types.md
@@ -5,7 +5,7 @@ description: Learn about the available node types in IPFS Companion.
 
 # Understand node types in IPFS Companion
 
-IPFS Companion's preferences screen allows you to choose from several different node types. The available types you'll see in your Companion preferences depends on the browser you're using (i.e. Firefox, Chrome, Brave), but the full list is as follows:
+IPFS Companion's preferences screen allows you to choose from different node types. The available types you'll see in your Companion preferences depends on the browser you're using (i.e. Firefox, Chrome, Brave), but the full list is as follows:
 
 [[toc]]
 
@@ -67,11 +67,25 @@ This node type offers the same benefits as an [external](#external) node, with a
 
 ## Embedded
 
+::: warning DEPRECATED
+
+js-ipfs has been deprecated in favor of [Helia](https://github.com/ipfs/helia) and will be removed in a future release of IPFS Companion. Improvements to Helia are ongoing, and we hope to have it ready for use in IPFS Companion once critical features like [webRTC Streams](https://github.com/w3c/webextensions/issues/72) are available in Chrome Manifest V3.
+
+:::
+
 An _embedded_ node is a js-ipfs instance running in the browser in-memory, without the need for any external software.
 
 ::: warning
 
 This node type is only for development and experimentation. Most users should use [external](#external) or [native](#native) node types instead.
+
+:::
+
+::: warning Deprecation Notice for Chrome Manifest V3
+
+Chrome Manifest V3 is the new version of the Chrome extension platform that IPFS Companion will support in the near future ([tracking issue](https://github.com/ipfs/ipfs-companion/issues/1152)). The embedded node type is not available in Chrome MV3 and will be removed from the extension in a future release.
+
+If you're using the embedded node type in Chrome, please switch to the external node type instead.
 
 :::
 
@@ -86,12 +100,6 @@ Please note that there are some limitations when running an embedded js-ipfs ins
   - Lack of connection closing ([ipfs/js-ipfs#962](https://github.com/ipfs/js-ipfs/issues/962))
   - Missing relay discovery ([js-ipfs/v0.29.x/examples/circuit-relaying](https://github.com/ipfs/js-ipfs/tree/v0.29.3/examples/circuit-relaying))
 - An embedded node _does not run_ when an external node is selected; every time you switch back to the embedded node, a new instance is created on demand, and it can take a few seconds for a newly running node to find peers.
-
-### Embedded + `chrome.sockets` (deprecated)
-
-::: warning
-This node type has been deprecated and is no longer supported by Chromium browsers. While this option still appears in IPFS Companion preferences, users of this node type are strongly urged to migrate to a different node type.
-:::
 
 ## Public
 

--- a/docs/how-to/companion-node-types.md
+++ b/docs/how-to/companion-node-types.md
@@ -83,7 +83,7 @@ This node type is only for development and experimentation. Most users should us
 
 ::: warning Deprecation Notice for Chrome Manifest V3
 
-Chrome Manifest V3 is the new version of the Chrome extension platform that IPFS Companion will support in the near future ([tracking issue](https://github.com/ipfs/ipfs-companion/issues/1152)). The embedded node type is not available in Chrome MV3 and will be removed from the extension in a future release.
+Chrome Manifest V3 is the new version of the Chrome extension platform that IPFS Companion will support in the near future. Currently, the embedded node type is unavailable in Chrome MV3 and will be removed from the extension in a future release. For further information, see the [tracking issue in GitHub](https://github.com/ipfs/ipfs-companion/issues/1152).
 
 If you're using the embedded node type in Chrome, please switch to the external node type instead.
 

--- a/docs/install/ipfs-companion.md
+++ b/docs/install/ipfs-companion.md
@@ -15,8 +15,6 @@ For its full functionality to be enabled, IPFS Companion requires a local IPFS n
 - [Install IPFS Kubo for Go](../install/command-line.md)
 - [Install IPFS for JavaScript](../install/js-ipfs.md)
 
-You can still use IPFS Companion without a local node running, although you will lose some functionality, such as the ability to load websites with DNSLink via a gateway.
-
 ## Install
 
 The easiest way to install IPFS Companion is through your browser's specific extensions and add-ons store:
@@ -34,7 +32,7 @@ IPFS Companion supercharges your browser for the DWeb with features including th
 
 IPFS Companion detects and tests requests for IPFS-like paths, such as `/ipfs/{cid}` or `/ipns/{peerid_or_host-with-dnslink}`, on any website. If a path is a valid IPFS address, it is redirected to load from your local gateway, which converts data from one protocol to another. The gateway at `localhost` will also automatically switch to a subdomain to provide a unique origin for each website. Providing a unique origin accommodates operations that are restricted to content that shares the same protocol, domain, and port, also known as [same-origin content](https://en.wikipedia.org/wiki/Same-origin_policy#:~:text=In%20computing%2C%20the%20same%2Dorigin,pages%20have%20the%20same%20origin).
 
-> `https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR`  
+> `https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR`
 > → `http://localhost:8080/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR`
 > → `http://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.ipfs.localhost:8080`
 
@@ -42,7 +40,7 @@ IPFS Companion detects and tests requests for IPFS-like paths, such as `/ipfs/{c
 
 IPFS Companion detects DNSLink info in the DNS records of websites. DNSLink is a simple protocol that links content and serviceability from DNS and leverages the DNS distributed architecture. See [Glossary > DNSLink](../concepts/glossary.md#dnslink). If a site uses DNSLink, IPFS Companion redirects the HTTP request to your local gateway:
 
-> `http://docs.ipfs.tech`  
+> `http://docs.ipfs.tech`
 > → `http://localhost:8080/ipns/docs.ipfs.tech` → `http://docs.ipfs.tech.ipns.localhost:8080/`
 
 ### Detect pages with `x-ipfs-path` headers


### PR DESCRIPTION
# Describe your changes
- Adds a deprecation notice for js-ipfs and provide a path forward.
- I am wondering if removing embedded node type as part of mv3 is a better option.
  - https://github.com/ipfs/ipfs-companion/issues/1220 


# Files changed

- docs/how-to/companion-node-types.md 

# What issue(s) does this address?

<!-- 
Ideally, your PR should reference an open GitHub issue that it addresses. Add links to any issues that this PR addresses. 
!-->

- https://github.com/ipfs/js-ipfs/issues/4336



## Checklist before requesting a review
- [ ] Passing the beta version of the **Check Markdown links for modified files** check. Action results can be viewed [here](https://github.com/ipfs/ipfs-docs/actions/workflows/action.yml).

## Checklist before merging
- [ ] Passing all required checks (The beta **Check Markdown links for modified files** check is not required)
