### PR TITLE
Update libp2p.md to account for docs.libp2p.io changes

### DIFF
--- a/docs/concepts/libp2p.md
+++ b/docs/concepts/libp2p.md
@@ -55,7 +55,7 @@ The features of Libp2p are listed below. For more information on each feature, c
 
 - [Peer identity](https://docs.libp2p.io/concepts/fundamentals/peers/#peer-id)
 
-- [Peer routing](https://docs.libp2p.io/introduction/#peer-routing)
+- [Peer routing](https://docs.libp2p.io/concepts/appendix/glossary/#peer-routing)
 
 - [Content discovery](https://docs.libp2p.io/concepts/introduction/overview/#content-discovery)
 

--- a/docs/concepts/libp2p.md
+++ b/docs/concepts/libp2p.md
@@ -1,17 +1,16 @@
 ---
 title: libp2p
 sidebarDepth: 0
-description: Learn about the Libp2p protocol and why it's an important ingredient in how IPFS works.
+description: Learn about the libp2p protocol and why it's an important ingredient in how IPFS works.
 related:
-  'What is Libp2p?': https://docs.libp2p.io/introduction/#what-is-libp2p
-  'Foundational Libp2p concepts': https://docs.libp2p.io/concepts/
-  'Getting started with Libp2p': https://docs.libp2p.io/guides/
-  'Examples of Libp2p key features': https://docs.libp2p.io/guides/
+  'What is libp2p?': https://docs.libp2p.io/concepts/introduction/overview/
+  'Foundational libp2p concepts': https://docs.libp2p.io/concepts/
+  'Getting started with libp2p': https://docs.libp2p.io/guides/
 ---
 
 # libp2p
 
-Libp2p, (short for “library peer-to-peer”) is a peer-to-peer (P2P) networking framework that enables the development of P2P applications. It consists of a collection of protocols, specifications, and libraries that facilitate P2P communication between network participants or, in other words, peers.
+libp2p, (short for “library peer-to-peer”) is a peer-to-peer (P2P) networking framework that enables the development of P2P applications. It consists of a collection of protocols, specifications, and libraries that facilitate P2P communication between network participants or, in other words, peers.
 
 ## P2P basics
 
@@ -19,14 +18,14 @@ P2P networks are _decentralized_, meaning that participants communicate directly
 
  - P2P networks do not require a privileged set of servers that behave differently from their clients, as in the predominant client-server model.
  - No central server or authority controls the network.
- 
+
 
 P2P networks can take many forms, including file-sharing systems like BitTorrent, blockchain networks like Bitcoin and Ethereum, and decentralized communication standards like Matrix. These systems all have different challenges and tradeoffs,
 but they share the goal of improving upon the traditional client-server networking model.
 
 ## Background of libp2p and IPFS
 
-Libp2p was initially developed as the wire protocol for the IPFS project, but has since phased out into a broader networking stack that a wide range of other projects use as a networking layer. It provides a set of specifications that can be adapted to support various protocols, allowing developers to create libp2p applications that can operate in multiple runtimes and networking environments.
+libp2p was initially developed as the wire protocol for the IPFS project, but has since phased out into a broader networking stack that a wide range of other projects use as a networking layer. It provides a set of specifications that can be adapted to support various protocols, allowing developers to create libp2p applications that can operate in multiple runtimes and networking environments.
 
 Discovering and connecting with other peers is a key challenge in P2P networking. Before libp2p, each P2P application had to develop its own solution, leading to a lack of reusable, well-documented P2P protocols. The IPFS team looked at existing research and networking applications for inspiration, but found few code implementations that were usable and adaptable. Existing implementations had problems like:
 
@@ -36,16 +35,16 @@ Discovering and connecting with other peers is a key challenge in P2P networking
 - No point of contact.
 - Being closed source, deprecated, or lacked specifications.
 - Unfriendly APIs.
-- Tight coupling with specific use cases. 
-- Lack of upgradeability. 
+- Tight coupling with specific use cases.
+- Lack of upgradeability.
 
 As a result, developers often had to reinvent the wheel each time they needed P2P protocols rather than being able to reuse existing solutions.
 
-Libp2p was designed to address these limitations.
+libp2p was designed to address these limitations.
 
 ## Features
 
-The features of Libp2p are listed below. For more information on each feature, click the link to navigate to the appropriate page in the [official Libp2p documentation](https://docs.libp2p.io).
+The features of libp2p are listed below. For more information on each feature, click the link to navigate to the appropriate page in the [official libp2p documentation](https://docs.libp2p.io).
 
 - [Flexible addressing](https://docs.libp2p.io/concepts/addressing/)
 
@@ -56,8 +55,6 @@ The features of Libp2p are listed below. For more information on each feature, c
 - [Peer identity](https://docs.libp2p.io/concepts/fundamentals/peers/#peer-id)
 
 - [Peer routing](https://docs.libp2p.io/concepts/appendix/glossary/#peer-routing)
-
-- [Content discovery](https://docs.libp2p.io/concepts/introduction/overview/#content-discovery)
 
 - [NAT traversal](https://docs.libp2p.io/concepts/nat/)
 
@@ -74,6 +71,6 @@ Check out the [libp2p documentation](https://docs.libp2p.io/concepts/pubsub/over
 - [The libp2p documentation](https://docs.libp2p.io/)
 - [The libp2p website](https://libp2p.io/)
 - [The libp2p connectivity site](https://connectivity.libp2p.io/)
-- [The libp2p YouTube channel to Libp2p](https://www.youtube.com/@libp2p630)
+- [The libp2p YouTube channel to libp2p](https://www.youtube.com/@libp2p630)
 - [The libp2p technical specifications](https://github.com/libp2p/specs)
 - [Protocol Labs Research - ResNetLab on Tour](https://research.protocol.ai/tutorials/resnetlab-on-tour/)


### PR DESCRIPTION
# Describe your changes
IPFS docs link to some libp2p concepts, but those links are broken after the libp2p docs refactor.


# Files changed
<!-- 
Add the paths of the files that are being updated in this PR
!-->
- docs/concepts/libp2p.md

# What issue(s) does this address?
- docs.libp2p.io had URL changes in 2022. It looks like some IPFS pages weren't updated.


# Does this update depend on any other PRs?
No

## Checklist before requesting a review
- [ ] Passing the beta version of the **Check Markdown links for modified files** check. Action results can be viewed [here](https://github.com/ipfs/ipfs-docs/actions/workflows/action.yml).

## Checklist before merging
- [ ] Passing all required checks (The beta **Check Markdown links for modified files** check is not required)
