### PR TITLE
1158: Callout that IPNS names work with DNSLink

### DIFF
--- a/docs/concepts/dnslink.md
+++ b/docs/concepts/dnslink.md
@@ -5,7 +5,7 @@ description: Learn how to map IPFS content to DNS names using DNSLink.
 
 # DNSLink
 
-DNSLink uses [DNS `TXT` records](https://en.wikipedia.org/wiki/TXT_record) to map a DNS name, like [`en.wikipedia-on-ipfs.org`](https://en.wikipedia-on-ipfs.org), to an IPFS address. Because you can edit your DNS records, you can use them to always point to the latest version of an object in IPFS. Since DNSLink uses DNS records, you can assign names, paths, and sub-domains that are easy to type, read, and remember.
+DNSLink uses [DNS `TXT` records](https://en.wikipedia.org/wiki/TXT_record) to map a DNS name, such as [`en.wikipedia-on-ipfs.org`](https://en.wikipedia-on-ipfs.org), to either an IPFS address or an [IPNS](../concepts/ipns.md) name. Because you can edit your DNS records, you can use them to always point to the latest version of an object in IPFS. Since DNSLink uses DNS records, you can assign names, paths, and sub-domains that are easy to type, read, and remember.
 
 A DNSLink address looks like an [IPNS](ipns.md) address, but it uses a DNS name in place of a hashed public key:
 

--- a/docs/concepts/ipns.md
+++ b/docs/concepts/ipns.md
@@ -33,7 +33,9 @@ Yet, there are many situations where content-addressed data needs to be regularl
 
 The InterPlanetary Name System (IPNS) is a system for creating such mutable pointers to CIDs known as **names** or **IPNS names**. IPNS names can be thought of as links that can be updated over time, while retaining the verifiability of content addressing.
 
-> **Note:** Technically, an IPNS name can point to an arbitrary content path (`/ipfs/` or `/ipns/`), including another IPNS name or DNSLink path. However, it most commonly points to a fully resolved and immutable path, i.e. `/ipfs/[CID]`.
+::: callout
+An IPNS name can point to any arbitrary content path (`/ipfs/` or `/ipns/`), *including another IPNS name or DNSLink path*. However, it most commonly points to a fully resolved and immutable path, i.e. `/ipfs/[CID]`.
+:::
 
 ## How IPNS works
 
@@ -201,7 +203,7 @@ See the following guide on [publishing IPNS names with Kubo and Helia](../how-to
 
 ## Alternatives to IPNS
 
-IPNS is not the only way to create mutable addresses on IPFS. You can also use [DNSLink](dnslink.md), which is currently much faster than IPNS and also uses human-readable names. Other community members are exploring ways to use blockchains to store common name records.
+IPNS is not the only way to create mutable addresses on IPFS. You can also use [DNSLink](dnslink.md), which is currently much faster than IPNS, uses human-readable names, and can also point to IPNS names. Other community members are exploring ways to use blockchains to store common name records.
 
 ## Further Resources
 


### PR DESCRIPTION
Per (very old) issue https://github.com/ipfs/ipfs-docs/issues/1158, we do not explicitly call out in the docs that IPNS names work with DNSLink. So, this PR makes minor updates to the following docs to make that more apparent:

- docs/concepts/dnslink.md
- docs/concepts/ipns.md
