### PR TITLE
Extra "\" in dnslink.md

### DIFF
--- a/docs/concepts/dnslink.md
+++ b/docs/concepts/dnslink.md
@@ -28,8 +28,8 @@ This not only makes DNSLink lookup more efficient by only returning relevant `TX
 For example, [`docs.ipfs.tech`](https://docs.ipfs.tech) loads because a `TXT` record exists for `_dnslink.docs.ipfs.tech`. If you look up the DNS records for `_dnslink.docs.ipfs.tech`, you'll see the DNSLink entry:
 
 ```shell
-dig +noall +answer TXT \_dnslink.docs.ipfs.tech
-> \_dnslink.docs.ipfs.tech. 30 IN TXT "dnslink=/ipfs/bafybeieenxnjdjm7vbr5zdwemaun4sw4iy7h4imlvvl433q6gzjg6awdpq"
+dig +noall +answer TXT _dnslink.docs.ipfs.tech
+> _dnslink.docs.ipfs.tech. 30 IN TXT "dnslink=/ipfs/bafybeieenxnjdjm7vbr5zdwemaun4sw4iy7h4imlvvl433q6gzjg6awdpq"
 
 ```
 


### PR DESCRIPTION
Remove suspicious \

# Describe your changes


The same dig command is present with and without "\". I think it looks suspicious. I've never seen a domain name start with \.

I just removed the bar.



# What issue(s) does this address?

# Does this update depend on any other PRs?

no

## Checklist before requesting a review
- [ ] Passing the beta version of the **Check Markdown links for modified files** check. Action results can be viewed [here](https://github.com/ipfs/ipfs-docs/actions/workflows/action.yml).

## Checklist before merging
- [ ] Passing all required checks (The beta **Check Markdown links for modified files** check is not required)
