### PR TITLE
Add Scheme and Lua client libraries

### DIFF
--- a/docs/reference/kubo-rpc-cli.md
+++ b/docs/reference/kubo-rpc-cli.md
@@ -36,3 +36,4 @@ RPC API clients are available in multiple languages, and are listed below. You c
 |               | [richardschneider/net-ipfs-http-client](https://github.com/richardschneider/net-ipfs-http-client)   | Active   |
 | C++           | [vasild/cpp-ipfs-api](https://github.com/vasild/cpp-ipfs-api)                    | Active   |
 | Erlang        | [hendry19901990/erlang-ipfs-http-client](https://github.com/hendry19901990/erlang-ipfs-http-client) | Inactive |
+| Scheme        | [siiky/ipfs.scm](https://git.sr.ht/~siiky/ipfs.scm) | Active |

--- a/docs/reference/kubo-rpc-cli.md
+++ b/docs/reference/kubo-rpc-cli.md
@@ -37,3 +37,4 @@ RPC API clients are available in multiple languages, and are listed below. You c
 | C++           | [vasild/cpp-ipfs-api](https://github.com/vasild/cpp-ipfs-api)                    | Active   |
 | Erlang        | [hendry19901990/erlang-ipfs-http-client](https://github.com/hendry19901990/erlang-ipfs-http-client) | Inactive |
 | Scheme        | [siiky/ipfs.scm](https://git.sr.ht/~siiky/ipfs.scm) | Active |
+| Lua           | [siiky/ipfs.lua](https://git.sr.ht/~siiky/ipfs.lua) | Active |


### PR DESCRIPTION
# Describe your changes

Now that https://github.com/ipfs/ipfs-docs/pull/1695 has been merged, and https://github.com/ipfs/ipfs-docs/issues/1194 closed, https://github.com/ipfs/ipfs-docs/issues/1194#issuecomment-1243483410 (previously https://github.com/ipfs/ipfs/pull/480) can be taken care of.

# Files changed

* `docs/reference/kubo-rpc-cli.md`

# Does this update depend on any other PRs?

No.