### PR TITLE
docs: clarify webtransport use cases for ipfs

### DIFF
--- a/docs/how-to/webtransport.md
+++ b/docs/how-to/webtransport.md
@@ -35,7 +35,7 @@ WebTransport in Kubo unlocks many use cases, including those listed below.
 - Browser nodes or light clients can function as "full" peers in a decentralized network.
 - Browser nodes can gossip directly with their peers, meaning they can receive and submit messages directly without relying on centralized infrastructure or interfaces like an HTTP/GraphQL API.
 - Fetch data from the [DHT](../concepts/dht.md) by directly connecting to a DHT server node.
-- Upload to a long term storage such as a [pinning service](../concepts/persistence.md) directly from the browser.
+- Upload data directly from the browser to long-term storage such as a [pinning service](../concepts/persistence.md) .
 - Decentralized peer-to-peer video streaming as a dApp.
 
 ## Using WebTransport with Kubo

--- a/docs/how-to/webtransport.md
+++ b/docs/how-to/webtransport.md
@@ -34,9 +34,8 @@ WebTransport in Kubo unlocks many use cases, including those listed below.
 
 - Browser nodes or light clients can function as "full" peers in a decentralized network.
 - Browser nodes can gossip directly with their peers, meaning they can receive and submit messages directly without relying on centralized infrastructure or interfaces like an HTTP/GraphQL API.
-- Browser extension cryptocurrency wallets can submit transactions directly to the blockchain.
 - Fetch data from the [DHT](../concepts/dht.md) by directly connecting to a DHT server node.
-- Upload to [Filecoin](https://docs.filecoin.io/) directly from the browser.
+- Upload to a long term storage such as a [pinning service](../concepts/persistence.md) directly from the browser.
 - Decentralized peer-to-peer video streaming as a dApp.
 
 ## Using WebTransport with Kubo

--- a/docs/how-to/webtransport.md
+++ b/docs/how-to/webtransport.md
@@ -35,7 +35,7 @@ WebTransport in Kubo unlocks many use cases, including those listed below.
 - Browser nodes or light clients can function as "full" peers in a decentralized network.
 - Browser nodes can gossip directly with their peers, meaning they can receive and submit messages directly without relying on centralized infrastructure or interfaces like an HTTP/GraphQL API.
 - Fetch data from the [DHT](../concepts/dht.md) by directly connecting to a DHT server node.
-- Upload data directly from the browser to long-term storage such as a [pinning service](../concepts/persistence.md) .
+- Upload data directly from the browser to long-term storage such as a [pinning service](../concepts/persistence.md).
 - Decentralized peer-to-peer video streaming as a dApp.
 
 ## Using WebTransport with Kubo


### PR DESCRIPTION
This is cosmetic, but IPFS Docs should not oversell on things that do not work today and/or are not related to IPFS at all.
Instead, I've added persistence to other IPFS nodes, such as pinning services (which works today).
