### PR TITLE
update native urls secn in ipfs in the browser

### DIFF
--- a/docs/how-to/address-ipfs-on-web.md
+++ b/docs/how-to/address-ipfs-on-web.md
@@ -222,12 +222,12 @@ An example is this website, [https://docs.ipfs.tech](https://docs.ipfs.tech).
 For a complete DNSLink guide, including tutorials, usage examples, and FAQs, see [dnslink.io](https://dnslink.io).
 :::
 
-## Native URLs
+## <a name=native-urls>IPFS-Scheme URLs</a>
 
-The native address format is the same as a [subdomain gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#subdomain-gateway) HTTP URL, but with two differences:
+URLs that combine the "native" IPFS address format with an IPFS-specific scheme are structured in a way very similar to `http`/`https`-scheme URLs" that rely on a [subdomain gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#subdomain-gateway) for their location-based authority component. These were historically called "Native URLs" since they combine a native IPFS address with an IPFS-native scheme, but note the differences between a subdomain-gateway HTTP(S) URL and a IPFS-scheme URL:
 
-- The protocol scheme is replaced by the `ipfs` or `ipns` namespace
-- The location-based authority component (the gateway host and port) is replaced with a CID
+- The `ipfs` or `ipns` protocol schemes are used for http, depending on the namespace (`ipns` is a subset of `ipfs`)
+- The location-based authority component (the gateway host and port) is replaced with a bare, native CID
 
 ```plaintext
 ipfs://{cid}/path/to/subresource/cat.jpg

--- a/docs/how-to/address-ipfs-on-web.md
+++ b/docs/how-to/address-ipfs-on-web.md
@@ -226,7 +226,7 @@ For a complete DNSLink guide, including tutorials, usage examples, and FAQs, see
 
 URLs that combine the "native" IPFS address format with an IPFS-specific scheme are structured in a way very similar to `http`/`https`-scheme URLs" that rely on a [subdomain gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#subdomain-gateway) for their location-based authority component. These were historically called "Native URLs" since they combine a native IPFS address with an IPFS-native scheme, but note the differences between a subdomain-gateway HTTP(S) URL and a IPFS-scheme URL:
 
-- The `ipfs` or `ipns` protocol schemes are used for http, depending on the namespace (`ipns` is a subset of `ipfs`)
+- The `ipfs` or `ipns` protocol schemes are used instead of `http`
 - The location-based authority component (the gateway host and port) is replaced with a bare, native CID
 
 ```plaintext


### PR DESCRIPTION
# Describe your changes

Renamed "Native URLs" to "IPFS-Scheme URLs" after discussion with some core folks in the filecoin slack earlier today.

# Files changed
docs/how-to/address-ipfs-on-web.md 


# What issue(s) does this address?

Just aligns terminology with practice and with browser-API terminology (topical because these specs are being linked to from applications for standards purposes)

note: I snuck a duplicate fragment-anchor into the heading so that old links directly to the renamed section would still work 

# Does this update depend on any other PRs?

nope
 

## Checklist before requesting a review
- [ ] Passing the beta version of the **Check Markdown links for modified files** check. Action results can be viewed [here](https://github.com/ipfs/ipfs-docs/actions/workflows/action.yml).

## Checklist before merging
- [ ] Passing all required checks (The beta **Check Markdown links for modified files** check is not required)
