### PR TITLE
chore: add warnings about outdated guides.

### DIFF
--- a/docs/quickstart/publish.md
+++ b/docs/quickstart/publish.md
@@ -6,7 +6,7 @@ description: 'Learn how to publish content with IPFS by pinning a file to a pinn
 # Publish a file with IPFS
 
 :::warning
-This guide is currently outdated due to changes with web3.storage.
+Some steps of this guide are currently outdated due to [changes with web3.storage](https://blog.web3.storage/posts/the-data-layer-is-here-with-the-new-web3-storage).
 :::
 
 In this quickstart guide, you will learn about [pinning services](../concepts/persistence.md#pinning-in-context) and how to use them to publish content-addressed data with IPFS. To learn the process, you will upload the file to a pinning service called [web3.storage](https://web3.storage/). By the end of this guide, you should have a better understanding of how content addressing and CIDs work from a high level.

--- a/docs/quickstart/publish.md
+++ b/docs/quickstart/publish.md
@@ -5,6 +5,10 @@ description: 'Learn how to publish content with IPFS by pinning a file to a pinn
 
 # Publish a file with IPFS
 
+:::warning
+This guide is currently outdated due to changes with web3.storage.
+:::
+
 In this quickstart guide, you will learn about [pinning services](../concepts/persistence.md#pinning-in-context) and how to use them to publish content-addressed data with IPFS. To learn the process, you will upload the file to a pinning service called [web3.storage](https://web3.storage/). By the end of this guide, you should have a better understanding of how content addressing and CIDs work from a high level.
 
 :::callout

--- a/docs/quickstart/publish_cli.md
+++ b/docs/quickstart/publish_cli.md
@@ -5,6 +5,10 @@ description: 'Learn how to publish content with IPFS by pinning a file to a pinn
 
 # Publish a file with IPFS using the command line
 
+:::warning
+This guide is currently outdated due to changes with web3.storage.
+:::
+
 Similar to the [Publish a file with IPFS](./publish.md) quickstart, this guide will teach you about [pinning services](../concepts/persistence.md#pinning-in-context) and how to use them to publish content-addressed data with IPFS. However, instead of using the [Web3 UI used in the related guide](./publish.md#upload-and-pin-a-file) , you will upload the file to [web3.storage](https://web3.storage/) using the [w3 command line interface](https://github.com/web3-storage/w3cli). By the end of this guide, you should have a better understanding of how content addressing and CIDs work from a high level, as well as how to use the w3 command line interface to publish data to IPFS.
 
 :::callout

--- a/docs/quickstart/publish_cli.md
+++ b/docs/quickstart/publish_cli.md
@@ -6,7 +6,7 @@ description: 'Learn how to publish content with IPFS by pinning a file to a pinn
 # Publish a file with IPFS using the command line
 
 :::warning
-This guide is currently outdated due to changes with web3.storage.
+Some steps of this guide are currently outdated due to [changes with web3.storage](https://blog.web3.storage/posts/the-data-layer-is-here-with-the-new-web3-storage).
 :::
 
 Similar to the [Publish a file with IPFS](./publish.md) quickstart, this guide will teach you about [pinning services](../concepts/persistence.md#pinning-in-context) and how to use them to publish content-addressed data with IPFS. However, instead of using the [Web3 UI used in the related guide](./publish.md#upload-and-pin-a-file) , you will upload the file to [web3.storage](https://web3.storage/) using the [w3 command line interface](https://github.com/web3-storage/w3cli). By the end of this guide, you should have a better understanding of how content addressing and CIDs work from a high level, as well as how to use the w3 command line interface to publish data to IPFS.


### PR DESCRIPTION
# Describe your changes

Add a warning about outdated guides at a temporary measure until these are updated. The challenge is that currently signing up for web3.storage requires a credit card which isn't ideal for a quickstart

