### PR TITLE
feat: add public utilities page

### DIFF
--- a/.github/styles/pln-ignore.txt
+++ b/.github/styles/pln-ignore.txt
@@ -14,6 +14,9 @@ Audius
 auspinner
 BitSwap
 bitswap
+bootstrappers
+bootstrapper
+bootstrap
 Blockchain
 blockchain
 blockchains

--- a/.github/styles/pln-ignore.txt
+++ b/.github/styles/pln-ignore.txt
@@ -54,11 +54,13 @@ Datastore
 datastore
 dClimate
 deduplicate
+Denylist
 deserialization
 Dheeraj
 DHT
 DHTs
 dialable
+discoverability
 DNS
 DNSAddr
 DNSLink
@@ -148,6 +150,7 @@ Minty
 Minty's
 multiaddr
 Multiaddress
+multiaddresses
 Multibase
 multibase
 Multicodec
@@ -214,9 +217,11 @@ sharding
 snapshotted
 stackparse
 stdout
+someguy
 Storj
 substring
 Sztandera
+takedown
 Testground
 testnet
 toolkits

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -187,6 +187,7 @@ module.exports = {
             },
             '/concepts/cod',
             '/concepts/comparisons',
+            '/concepts/public-utilities',
             '/concepts/usage-ideas-examples',
             ['/concepts/measuring', 'Measuring the network'],
             '/concepts/faq',

--- a/docs/concepts/ipfs-gateway.md
+++ b/docs/concepts/ipfs-gateway.md
@@ -166,48 +166,6 @@ For more information on working with gateways, see [best practices](../how-to/ga
 
 If you would like to read the technical specifications for the various gateway types, and learn more about how to implement a gateway, see the [IPFS HTTP Gateways specification](https://specs.ipfs.tech/http-gateways/) page for more information.
 
-## Frequently asked questions (FAQs)
-
-### What is the ipfs.io gateway?
-
-The ipfs.io gateway makes it possible for Internet users to access and view data hosted by third parties on the IPFS network. The ipfs.io gateway is a community resource run by Protocol Labs to help developers build on IPFS.
-
-### How is the ipfs.io gateway different from other gateways?
-
-The ipfs.io gateway is a gateway run by Protocol Labs. Many other entities run their own gateways with different policies around throttling and access, which may be subject to other local laws and regulations. A [list of public gateways is available here](https://ipfs.github.io/public-gateway-checker/).
-
-Protocol Labs does not store or host the data that is viewable through the ipfs.io gateway. Rather, the ipfs.io gateway allows users to view content hosted by third parties. Protocol Labs does not have any control over the data that is viewed through the ipfs.io gateway, nor does Protocol Labs have control over other gateways.
-
-### Is the ipfs.io gateway a data storage host?
-
-No. The ipfs.io gateway is a passthrough portal to data hosted by third parties on nodes in the IPFS network. It is not a data storage host.
-
-### Can websites rely on the ipfs.io gateway for hosting?
-
-No. Websites should not rely on the ipfs.io gateway for hosting of any kind. The ipfs.io gateway is a community resource run by Protocol Labs to help developers build on IPFS. Users of the ipfs.io gateway must use resources sparingly. Protocol Labs will throttle or ban users who overuse or misuse community resources, including relying on the ipfs.io gateway for website hosting or violating the Community Code of Conduct.
-
-### How does the ipfs.io Gateway handle global data regulations?
-
-Protocol Labs complies with the laws and regulations of relevant jurisdictions.
-
-As explained above, the ipfs.io gateway is not a website hosting provider or data storage provider, and Protocol Labs cannot remove material from the Internet that is accessible through the ipfs.io gateway.
-
-### Who is responsible for the content that is viewed through the ipfs.io gateway?
-
-Users of the ipfs.io gateway are required to comply with all applicable laws and regulations while using the ipfs.io gateway.
-
-The ipfs.io gateway is not a data storage provider or website host. The ipfs.io gateway allows users to view content hosted by third parties over which Protocol Labs exercises no control. The fact that certain content is viewable through the ipfs.io gateway does not mean it is hosted by the ipfs.io gateway or that Protocol Labs can do anything to delete that content.
-
-As explained above, the ipfs.io gateway is not a website hosting provider or data storage provider, and Protocol Labs cannot remove material from the Internet that is accessible through the ipfs.io gateway. If you believe that material accessible through the ipfs.io gateway is illegal or violates your copyright, you are encouraged to directly notify whoever is hosting or controls that data.
-
-While the ipfs.io gateway does not serve as a host for data or websites, in appropriate circumstances, Protocol Labs can disable the ability to view certain content via the ipfs.io gateway. This does not mean that the data itself has been taken down from the network but rather that the content is not viewable using the ipfs.io gateway. This also will not impact the availability of the data through other gateways run by other parties.
-
-You can report abuse by emailing abuse@protocol.ai. When appropriate, we will disable access through the ipfs.io gateway to the specific content set forth in your abuse report.
-
-### Can Protocol Labs take down content viewable through the ipfs.io gateway?
-
-No. The ipfs.io gateway is one of many portals used to view content stored by third parties on the Internet. Protocol Labs is not hosting that content and cannot take it down, but it can block the ability of users to view that content via the ipfs.io gateway in appropriate circumstances.
-
 ## Learning more
 
 - [A Practical Explainer for IPFS Gateways – Part 1](https://blog.ipfs.tech/2022-06-09-practical-explainer-ipfs-gateways-1/), [Part 2](https://blog.ipfs.tech/2022-06-30-practical-explainer-ipfs-gateways-2/)

--- a/docs/concepts/ipfs-gateway.md
+++ b/docs/concepts/ipfs-gateway.md
@@ -33,7 +33,7 @@ When a client request for a CID reaches an IPFS gateway, the gateway first check
 
 The CID retrieval process is composed of two parts, content discovery / routing and content retrieval:
 
-1. In the **content discovery / routing** step, the gateway will determine <VueCustomTooltip label="An IPFS network peer that can provide data specified by a particular CID upon request." underlined multiline>provider</VueCustomTooltip>  location; that is, _where_ the data specified by the CID can be found:
+1. In the **content discovery / routing** step, the gateway will determine <VueCustomTooltip label="An IPFS network peer that can provide data specified by a particular CID upon request." underlined multiline>provider</VueCustomTooltip> location; that is, _where_ the data specified by the CID can be found:
 
    - Asking peers that it is directly connected to if they have the data specified by the CID.
    - Query the DHT for the IDs and network addresses of peers that have the data specified by the CID.
@@ -65,14 +65,8 @@ A gateway behind a firewall represents just one potential location for a private
 
 ### Public gateways
 
-Public gateway operators include:
+For more information about public gateways, see the [](./public-utilities.md#public-ipfs-gateways)
 
-- Protocol Labs, which deploys the public gateway `https://ipfs.io`.
-- Third-party public gateways, such as `https://cf-ipfs.com`.
-
-Protocol Labs maintains a [list of public gateways](https://ipfs.github.io/public-gateway-checker/) and their status.
-
-[Web3IMG](https://web3img.com) also maintains an unofficial [list of public gateways](https://bestipfs.net). Please do your research before using any third-party gateways or websites.
 
 ## Gateway types
 
@@ -89,7 +83,7 @@ There are multiple gateway types, each with specific use case, security, perform
 
 ### Read-only gateways
 
-_Read-only gateways_ are the simplest kind of gateway. This gateway type provides a way to fetch IPFS content using the HTTP GET method. 
+_Read-only gateways_ are the simplest kind of gateway. This gateway type provides a way to fetch IPFS content using the HTTP GET method.
 
 ### Authenticated gateways
 
@@ -213,4 +207,4 @@ No. The ipfs.io gateway is one of many portals used to view content stored by th
 
 - [A Practical Explainer for IPFS Gateways – Part 1](https://blog.ipfs.tech/2022-06-09-practical-explainer-ipfs-gateways-1/), [Part 2](https://blog.ipfs.tech/2022-06-30-practical-explainer-ipfs-gateways-2/)
 - [Kubo: Gateway configuration options](https://github.com/ipfs/kubo/blob/master/docs/config.md#gateway)
-- [IPFS HTTP Gateways specification](https://specs.ipfs.tech/http-gateways/) 
+- [IPFS HTTP Gateways specification](https://specs.ipfs.tech/http-gateways/)

--- a/docs/concepts/ipfs-gateway.md
+++ b/docs/concepts/ipfs-gateway.md
@@ -11,7 +11,7 @@ related:
 
 # IPFS Gateway
 
-An _IPFS gateway_ is a web-based service that gets content from the IPFS network and makes it available via HTTP, allowing IPFS-incompatible browsers, tools and software to benefit from the IPFS public network. For example, some browsers or tools like [Curl](https://curl.haxx.se/) or [Wget](https://www.gnu.org/software/wget/) don't support IPFS natively and cannot access to IPFS content using canonical addressing like `ipfs://{CID}/{optional path to resource}`. While tools like [IPFS Companion](https://github.com/ipfs-shipyard/ipfs-companion) add browser support for native IPFS URLs, this is not always an option. As such, there are multiple gateway types and <VueCustomTooltip label="A way to address data by its hash rather than its location (IPs)." underlined multiline>gateway providers</VueCustomTooltip> available so that applications of all kinds can interface with IPFS using HTTP.
+An _IPFS gateway_ is a web-based service that gets content from an IPFS network (private, or the public swarm backed by Amino DHT), and makes it available via HTTP, allowing IPFS-incompatible browsers, tools and software to benefit from [content-addressing](https://docs.ipfs.tech/concepts/content-addressing/). For example, some browsers or tools like [Curl](https://curl.haxx.se/) or [Wget](https://www.gnu.org/software/wget/) don't support IPFS natively and cannot access to IPFS content using canonical addressing like `ipfs://{CID}/{optional path to resource}`. While tools like [IPFS Companion](https://github.com/ipfs-shipyard/ipfs-companion) add browser support for native IPFS URLs, this is not always an option. As such, there are multiple gateway types and <VueCustomTooltip label="A way to address data by its hash rather than its location (IPs)." underlined multiline>gateway providers</VueCustomTooltip> available so that applications of all kinds can interface with IPFS using HTTP.
 
 This page discusses:
 
@@ -70,7 +70,7 @@ This [tutorial configuring an IPFS gateway on a Google Cloud platform](https://b
 
 ### Public gateways
 
-For more information about public gateways, see the [](./public-utilities.md#public-ipfs-gateways)
+For more information about public gateways, see the [Public IPFS Gateways](./public-utilities.md#public-ipfs-gateways)
 
 
 ## Gateway types

--- a/docs/concepts/ipfs-gateway.md
+++ b/docs/concepts/ipfs-gateway.md
@@ -11,13 +11,16 @@ related:
 
 # IPFS Gateway
 
-An _IPFS gateway_ provides an HTTP-based service that allows IPFS-incompatible browsers, tools and software to access IPFS content. For example, some browsers or tools like [Curl](https://curl.haxx.se/) or [Wget](https://www.gnu.org/software/wget/) don't support IPFS natively and cannot access to IPFS content using canonical addressing like `ipfs://{CID}/{optional path to resource}`. While tools like [IPFS Companion](https://github.com/ipfs-shipyard/ipfs-companion) add browser support for native IPFS URLs, this is not always an option. As such, there are multiple gateway types and <VueCustomTooltip label="A way to address data by its hash rather than its location (IPs)." underlined multiline>gateway providers</VueCustomTooltip> available so that applications of all kinds can interface with IPFS using HTTP.
+An _IPFS gateway_ is a web-based service that gets content from the IPFS network and makes it available via HTTP, allowing IPFS-incompatible browsers, tools and software to benefit from the IPFS public network. For example, some browsers or tools like [Curl](https://curl.haxx.se/) or [Wget](https://www.gnu.org/software/wget/) don't support IPFS natively and cannot access to IPFS content using canonical addressing like `ipfs://{CID}/{optional path to resource}`. While tools like [IPFS Companion](https://github.com/ipfs-shipyard/ipfs-companion) add browser support for native IPFS URLs, this is not always an option. As such, there are multiple gateway types and <VueCustomTooltip label="A way to address data by its hash rather than its location (IPs)." underlined multiline>gateway providers</VueCustomTooltip> available so that applications of all kinds can interface with IPFS using HTTP.
 
 This page discusses:
 
-- The IPFS gateway request lifecycle
-- The several types of gateways.
-- Gateway role in the use of IPFS.
+- [Gateway request lifecycle](#gateway-request-lifecycle)
+- [Gateway providers](#gateway-providers)
+- [Gateway types](#gateway-types)
+- [Working with gateways](#working-with-gateways)
+- [Implementing gateways](#implementing-gateways)
+- [FAQs](#frequently-asked-questions-faqs)
 
 ## Gateway request lifecycle
 
@@ -59,9 +62,11 @@ Your machine may host a gateway as a local service; e.g., at `localhost:8080`. Y
 
 ### Private gateways
 
-Running [IPFS Desktop](https://github.com/ipfs-shipyard/ipfs-desktop#ipfs-desktop) or another form of IPFS node triggers connection attempts to other IPFS peers. Private network administrators may treat such connection attempts as potential security vulnerabilities. Private IPFS gateway servers located inside the private network and running a trusted code base provide an alternative architecture for read/write access to externally-hosted IPFS content.
+_Private gateways_ are configured to limit access to requests from specific domains or parts of the public internet. 
 
-A gateway behind a firewall represents just one potential location for a private gateway. More generally, one may consider any gateway as a _private gateway_ when configured to limit access to requests from specific domains or parts of the public internet. This [tutorial configuring an IPFS gateway on a Google Cloud platform](https://blog.stacktical.com/ipfs/gateway/dapp/2019/09/21/ipfs-server-google-cloud-platform.html) includes a description of constraining access.
+They are frequently, but not exclusively, used behind firewalls. Running [IPFS Desktop](https://github.com/ipfs-shipyard/ipfs-desktop#ipfs-desktop) or another form of IPFS node triggers connection attempts to other IPFS peers. Private network administrators may treat such connection attempts as potential security vulnerabilities. Private IPFS gateway servers located inside the private network and running a trusted code base provide an alternative architecture for read/write access to externally-hosted IPFS content.
+
+This [tutorial configuring an IPFS gateway on a Google Cloud platform](https://blog.stacktical.com/ipfs/gateway/dapp/2019/09/21/ipfs-server-google-cloud-platform.html) includes information on constraining access for a private gateway setup.
 
 ### Public gateways
 
@@ -157,7 +162,7 @@ Currently HTTP gateways may access both IPFS and IPNS services:
 
 For more information on working with gateways, see [best practices](../how-to/gateway-best-practices.md) and [troubleshooting](../how-to/gateway-troubleshooting.md).
 
-## Implementing using the spec
+## Implementing gateways
 
 If you would like to read the technical specifications for the various gateway types, and learn more about how to implement a gateway, see the [IPFS HTTP Gateways specification](https://specs.ipfs.tech/http-gateways/) page for more information.
 

--- a/docs/concepts/public-utilities.md
+++ b/docs/concepts/public-utilities.md
@@ -6,7 +6,7 @@ description: Information about hosted public utilities such as public gateways a
 
 # Public IPFS Utilities
 
-The IPFS Foundation (and Protocol Labs in the past), Cloudflare, and several other organizations provide hosted public utilities to the community on a best-effort basis. As such, it is not intended to be part of your critical path or production infrastructure.
+The IPFS Foundation (and Protocol Labs in the past) and several other organizations provide hosted public utilities to the community on a best-effort basis. As such, it is not intended to be part of your critical path or production infrastructure.
 
 These include [IPFS Gateways](./ipfs-gateway.md) and hosted [Delegated Routing V1 endpoints](./nodes#delegated-routing).
 
@@ -16,7 +16,7 @@ These IPFS gateways and delegated routing endpoints make it easier to retrieve d
 
 ## Waterworks
 
-The IP Shipyard team with support from the IPFS Foundation, operates the Waterwork infrastructure:
+The IPFS Foundation provides the following Waterworks infrastructure:
 
 - **`https://ipfs.io`**: Path resolution gateway
 - **`https://dweb.link`**: Subdomain resolution gateway
@@ -51,7 +51,7 @@ Browsers and low-powered devices can make a single HTTP call to a _Delegated Rou
 
 ### Waterworks Delegating Routing Endpoint
 
-The IP Shipyard team with support from the IPFS Foundation, operates a public good delegated routing endpoint backed by [**someguy**](https://github.com/ipfs/someguy) with the URL **`https://delegated-ipfs.dev/routing/v1`**
+The IPFS Foundation provides a public good delegated routing endpoint backed by [**someguy**](https://github.com/ipfs/someguy) with the URL **`https://delegated-ipfs.dev/routing/v1`**
 
 Under the hood, someguy handles requests by looking up the DHT and Network Indexer.
 

--- a/docs/concepts/public-utilities.md
+++ b/docs/concepts/public-utilities.md
@@ -8,7 +8,7 @@ description: Information about hosted public utilities such as public gateways a
 
 The IPFS Foundation (and Protocol Labs in the past) and several other organizations provide hosted public utilities to the community on a best-effort basis. As such, it is not intended to be part of your critical path or production infrastructure.
 
-These include [IPFS Gateways](./ipfs-gateway.md) and hosted [Delegated Routing V1 endpoints](./nodes#delegated-routing).
+These include [IPFS Gateways](./ipfs-gateway.md), hosted [Delegated Routing V1 endpoints](./nodes#delegated-routing), and the [Amino DHT](./glossary.md#amino) [Bootstrappers](./nodes.md#bootstrap).
 
 These utilities make it easier to retrieve data from the IPFS network in resource-constrained environments such as browsers and low-powered devices.
 
@@ -53,3 +53,52 @@ The IPFS Foundation provides a public delegated routing endpoint backed by [**so
 Under the hood, someguy handles requests by looking up the DHT and Network Indexer.
 
 This endpoint can also be useful for debugging discoverability of CIDs, for example: [https://delegated-ipfs.dev/routing/v1/providers/bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4](https://delegated-ipfs.dev/routing/v1/providers/bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4) will show the providers for the CID `bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4`.
+
+## Amino DHT Bootstrappers
+
+For an IPFS node to join the Amino DHT, it needs to discover other peers. Bootstrap nodes assist with this process.
+
+The IPFS Foundation provides several public bootstrap nodes that are published as a TXT record to DNS at `_dnsaddr.bootstrap.libp2p.io`:
+
+- `/dnsaddr/sg1.bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt`
+- `/dnsaddr/sv15.bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN`
+- `/dnsaddr/am6.bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb`
+- `/dnsaddr/ny5.bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa`
+
+> **Note:** You can query DNS for the specific records with the following command: `dig +short TXT _dnsaddr.bootstrap.libp2p.io`
+
+## Frequently Asked Questions (FAQs)
+
+### How is the ipfs.io gateway different from other gateways?
+
+The ipfs.io gateway is a gateway run by The IPFS Foundation. Many other entities run their own gateways with different policies around throttling and access, which may be subject to other local laws and regulations. A [list of public gateways is available here](https://ipfs.github.io/public-gateway-checker/).
+
+The IPFS Foundation does not store or host the data that is viewable through the ipfs.io gateway. Rather, the ipfs.io gateway allows users to view content hosted by third parties. The IPFS Foundation does not have any control over the data that is viewed through the ipfs.io gateway, nor does the IPFS Foundation have control over other gateways.
+
+### Is the ipfs.io gateway a data storage host?
+
+No. The ipfs.io gateway is a passthrough portal to data hosted by third parties on nodes in the IPFS network. It is not a data storage host.
+
+### Can websites rely on the ipfs.io gateway for hosting?
+
+No. Websites should not rely on the ipfs.io gateway for hosting of any kind. The ipfs.io gateway is a community resource run by the IPFS Foundation to help developers build on IPFS. Users of the ipfs.io gateway must use resources sparingly. The IPFS Foundation will throttle or ban users who overuse or misuse community resources, including relying on the ipfs.io gateway for website hosting or violating the Community Code of Conduct.
+
+### How does the ipfs.io Gateway handle global data regulations?
+
+The IPFS Foundation complies with the laws and regulations of relevant jurisdictions.
+
+As explained above, the ipfs.io gateway is not a website hosting provider or data storage provider, and the IPFS Foundation cannot remove material from the Internet that is accessible through the ipfs.io gateway.
+
+### Who is responsible for the content that is viewed through the ipfs.io gateway?
+
+Users of the ipfs.io gateway are required to comply with all applicable laws and regulations while using the ipfs.io gateway.
+
+The ipfs.io gateway is not a data storage provider or website host. The ipfs.io gateway allows users to view content hosted by third parties over which the IPFS Foundation exercises no control. The fact that certain content is viewable through the ipfs.io gateway does not mean it is hosted by the ipfs.io gateway or that the IPFS Foundation can do anything to delete that content.
+
+As explained above, the ipfs.io gateway is not a website hosting provider or data storage provider, and the IPFS Foundation cannot remove material from the Internet that is accessible through the ipfs.io gateway. If you believe that material accessible through the ipfs.io gateway is illegal or violates your copyright, you are encouraged to directly notify whoever is hosting or controls that data.
+
+While the ipfs.io gateway does not serve as a host for data or websites, in appropriate circumstances, the IPFS Foundation can disable the ability to view certain content via the ipfs.io gateway. This does not mean that the data itself has been taken down from the network but rather that the content is not viewable using the ipfs.io gateway. This also will not impact the availability of the data through other gateways run by other parties.
+
+### Can the IPFS Foundation take down content viewable through the ipfs.io gateway?
+
+No. The ipfs.io gateway is one of many portals used to view content stored by third parties on the Internet. The IPFS Foundation is not hosting that content and cannot take it down, but it can block the ability of users to view that content via the ipfs.io gateway in appropriate circumstances.

--- a/docs/concepts/public-utilities.md
+++ b/docs/concepts/public-utilities.md
@@ -1,0 +1,58 @@
+---
+title: Public IPFS Utilities
+sidebarDepth: 1
+description: Information about hosted public utilities such as public gateways and hosted delegated routing endpoints
+---
+
+# Public IPFS Utilities
+
+The IPFS Foundation (and Protocol Labs in the past), Cloudflare, and several other organizations provide hosted public utilities to the community on a best-effort basis. As such, it is not intended to be part of your critical path or production infrastructure.
+
+These include [IPFS Gateways](./ipfs-gateway.md) and hosted [Delegated Routing V1 endpoints](./nodes#delegated-routing).
+
+These IPFS gateways and delegated routing endpoints make it easier to retrieve data from the IPFS network in resource-constrained environments such as browsers and low-powered devices.
+
+## Public IPFS Gateways
+
+## Waterworks
+
+The IP Shipyard team with support from the IPFS Foundation, operates the Waterwork infrastructure:
+
+- **`https://ipfs.io`**: Path resolution gateway
+- **`https://dweb.link`**: Subdomain resolution gateway
+- **`https://trustless-gateway.link`**: [trustless only gateway](https://specs.ipfs.tech/http-gateways/trustless-gateway/)
+- **`https://delegated-ipfs.dev/routing/v1`**: Hosted Delegated Routing V1 endpoint backed by [**someguy**](https://github.com/ipfs/someguy)
+
+The Waterworks gateways block abusive content using the [Bad Bits Denylist](https://badbits.dwebops.pub/).
+
+To report abusive content and content breaches of the [IPFS Community Code of Conduct](https://ipfs.fyi/coc), please send an email with the CIDs to abuse@ipfs.io.
+
+To report any technical problems with these gateways, you can open an issue in the [Waterworks Community repository](https://github.com/ipshipyard/waterworks-community)
+
+### Abuse Policy
+
+When a takedown request for the ipfs.io and/or `dweb.link` gateway(s) is first received at abuse@ipfs.io, the sender will receive an automated system receipt. Next, someone from the takedown team will vet the request to validate that it is legitimate and should be accepted. Once the validity of the request has been established, it will be submitted for further processing.
+
+From there, an internal system extracts the relevant information from the request and generates an entry for it in our takedown lists. The list is then published to our gateway nodes, and the content in question will return a 410 status when visited.
+
+Your browser may have a local cache of the content in question and might not reflect that something has been blocked on the gateways. To avoid browser caching, attempt to view the content using your browser's incognito or private mode. You can also prevent caching issues by using a command-line tool such as Curl or Wget.
+
+## Other Public Gateways
+
+Additionally, there's a community-maintained [tool for finding and testing public gateways](https://ipfs.github.io/public-gateway-checker/) such as the one operated by Cloudflare: `https://cf-ipfs.com`.
+
+## Delegated Routing
+
+While IPFS Gateways are immensely helpful in doing all the heavy lifting of finding providers for CIDs and retrieving them, they can be a choke point for retrieval and a point of centralization.
+
+Hosted [_Delegated Routing_](./nodes.md#delegated-routing) endpoints are a key step towards eliminating the emergent centralization of public gateways thereby increasing the health of the network.
+
+Browsers and low-powered devices can make a single HTTP call to a _Delegated Routing_ endpoint with the CID they are looking to retrieve. The endpoint returns the [multiaddresses](./glossary.md#multiaddr) of the providers for the CID, from which the browser can download directly.
+
+### Waterworks Delegating Routing Endpoint
+
+The IP Shipyard team with support from the IPFS Foundation, operates a public good delegated routing endpoint backed by [**someguy**](https://github.com/ipfs/someguy) with the URL **`https://delegated-ipfs.dev/routing/v1`**
+
+Under the hood, someguy handles requests by looking up the DHT and Network Indexer.
+
+This endpoint can also be useful for debugging discoverability of CIDs, for example: [https://delegated-ipfs.dev/routing/v1/providers/bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4](https://delegated-ipfs.dev/routing/v1/providers/bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4) will show the providers for the CID `bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4`.

--- a/docs/concepts/public-utilities.md
+++ b/docs/concepts/public-utilities.md
@@ -16,9 +16,9 @@ These utilities make it easier to retrieve data from the IPFS network in resourc
 
 The IPFS Foundation provides the following public gateways:
 
-- **`https://ipfs.io`**: Path resolution gateway
-- **`https://dweb.link`**: Subdomain resolution gateway
-- **`https://trustless-gateway.link`**: [trustless only gateway](https://specs.ipfs.tech/http-gateways/trustless-gateway/)
+- **`https://ipfs.io`**: [Path resolution](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#path-gateway) gateway
+- **`https://dweb.link`**: [Subdomain resolution](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#subdomain-gateway) gateway
+- **`https://trustless-gateway.link`**: Gateway limited to [trustless and verifiable responses](https://docs.ipfs.tech/reference/http/gateway/#trustless-verifiable-retrieval)
 
 These gateways block abusive content using the [Bad Bits Denylist](https://badbits.dwebops.pub/).
 
@@ -28,7 +28,7 @@ Technical operations are run by the Waterworks Community on behalf of the IPFS F
 
 ### Abuse Policy
 
-When a takedown request for the ipfs.io and/or `dweb.link` gateway(s) is first received at abuse@ipfs.io, the sender will receive an automated system receipt. Next, someone from the takedown team will vet the request to validate that it is legitimate and should be accepted. Once the validity of the request has been established, it will be submitted for further processing.
+When a takedown request for the `ipfs.io` and/or `dweb.link` gateway(s) is first received at abuse@ipfs.io, the sender will receive an automated system receipt. Next, someone from the takedown team will vet the request to validate that it is legitimate and should be accepted. Once the validity of the request has been established, it will be submitted for further processing.
 
 From there, an internal system extracts the relevant information from the request and generates an entry for it in our takedown lists. The list is then published to our gateway nodes, and the content in question will return a 410 status when visited.
 

--- a/docs/concepts/public-utilities.md
+++ b/docs/concepts/public-utilities.md
@@ -10,24 +10,21 @@ The IPFS Foundation (and Protocol Labs in the past) and several other organizati
 
 These include [IPFS Gateways](./ipfs-gateway.md) and hosted [Delegated Routing V1 endpoints](./nodes#delegated-routing).
 
-These IPFS gateways and delegated routing endpoints make it easier to retrieve data from the IPFS network in resource-constrained environments such as browsers and low-powered devices.
+These utilities make it easier to retrieve data from the IPFS network in resource-constrained environments such as browsers and low-powered devices.
 
 ## Public IPFS Gateways
 
-## Waterworks
-
-The IPFS Foundation provides the following Waterworks infrastructure:
+The IPFS Foundation provides the following public gateways:
 
 - **`https://ipfs.io`**: Path resolution gateway
 - **`https://dweb.link`**: Subdomain resolution gateway
 - **`https://trustless-gateway.link`**: [trustless only gateway](https://specs.ipfs.tech/http-gateways/trustless-gateway/)
-- **`https://delegated-ipfs.dev/routing/v1`**: Hosted Delegated Routing V1 endpoint backed by [**someguy**](https://github.com/ipfs/someguy)
 
-The Waterworks gateways block abusive content using the [Bad Bits Denylist](https://badbits.dwebops.pub/).
+These gateways block abusive content using the [Bad Bits Denylist](https://badbits.dwebops.pub/).
 
 To report abusive content and content breaches of the [IPFS Community Code of Conduct](https://ipfs.fyi/coc), please send an email with the CIDs to abuse@ipfs.io.
 
-To report any technical problems with these gateways, you can open an issue in the [Waterworks Community repository](https://github.com/ipshipyard/waterworks-community)
+Technical operations are run by the Waterworks Community on behalf of the IPFS Foundation. To report any technical problems with these gateways, you can open an issue in the [Waterworks Community repository](https://github.com/ipshipyard/waterworks-community).
 
 ### Abuse Policy
 
@@ -45,13 +42,13 @@ Additionally, there's a community-maintained [tool for finding and testing publi
 
 While IPFS Gateways are immensely helpful in doing all the heavy lifting of finding providers for CIDs and retrieving them, they can be a choke point for retrieval and a point of centralization.
 
-Hosted [_Delegated Routing_](./nodes.md#delegated-routing) endpoints are a key step towards eliminating the emergent centralization of public gateways thereby increasing the health of the network.
+[_Delegated Routing_](./nodes.md#delegated-routing) endpoints are a key step towards eliminating the emergent centralization of public gateways thereby increasing the health of the network.
 
 Browsers and low-powered devices can make a single HTTP call to a _Delegated Routing_ endpoint with the CID they are looking to retrieve. The endpoint returns the [multiaddresses](./glossary.md#multiaddr) of the providers for the CID, from which the browser can download directly.
 
-### Waterworks Delegating Routing Endpoint
+### Delegated Routing Endpoint
 
-The IPFS Foundation provides a public good delegated routing endpoint backed by [**someguy**](https://github.com/ipfs/someguy) with the URL **`https://delegated-ipfs.dev/routing/v1`**
+The IPFS Foundation provides a public delegated routing endpoint backed by [**someguy**](https://github.com/ipfs/someguy) with the URL **`https://delegated-ipfs.dev/routing/v1`**
 
 Under the hood, someguy handles requests by looking up the DHT and Network Indexer.
 


### PR DESCRIPTION
## What this PR does

This PR adds a new page on public utilities infrastructure.

There's some nuance with the wording of who's operating the infra we need to get right. Would be good to hammer this out in this PR


## TODO

- [x] Update gateways page FAQ based on whatever we decide here
- [x] Add information on the Amino DHT bootstrappers (or is that libp2p teritory)
