### PR TITLE
fix: remove duplicate 'than' in 'Get Started' section

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -5,7 +5,7 @@ description: There are several different ways you can install and interact with 
 
 # Get Started
 
-IPFS is a collection of protocols, packages, and specifications that allow computers to send and receive data. Because of this, users can interact with and use IPFS in many different ways. A developer building network applications will use a different set of tools to interact with IPFS than than someone who wants to store files on IPFS. Pick the one that best suits what you're here to do.
+IPFS is a collection of protocols, packages, and specifications that allow computers to send and receive data. Because of this, users can interact with and use IPFS in many different ways. A developer building network applications will use a different set of tools to interact with IPFS than someone who wants to store files on IPFS. Pick the one that best suits what you're here to do.
 
 ## Publish files with a pinning service
 


### PR DESCRIPTION
# Describe your changes
<!-- 
Fixed a typographical error in the 'Get Started' section by removing a duplicated 'than'. This change improves the readability and professionalism of our documentation, ensuring a better experience for users following the initial setup instructions.
!-->


# Files changed
<!-- 
Add the paths of the files that are being updated in this PR
!-->
- <!-- README.md: https://github.com/TTNguyenDev/ipfs-docs/blob/main/docs/install/README.md#get-started!-->


# What issue(s) does this address?
- #1834 
# Does this update depend on any other PRs?

<!-- 
Add links to any PRs that this PR depends on. For example, if this is a documentation update describing a new feature that imust be tested and merged before the documentation can be published, link to that PR here
!-->

- 
- 

## Checklist before requesting a review
- [ ] Passing the beta version of the **Check Markdown links for modified files** check. Action results can be viewed [here](https://github.com/ipfs/ipfs-docs/actions/workflows/action.yml).

## Checklist before merging
- [ ] Passing all required checks (The beta **Check Markdown links for modified files** check is not required)
