### PR TITLE
Add ExIPFS - an active rpc client

### DIFF
--- a/docs/reference/kubo-rpc-cli.md
+++ b/docs/reference/kubo-rpc-cli.md
@@ -39,3 +39,4 @@ RPC API clients are available in multiple languages, and are listed below. You c
 | Erlang        | [hendry19901990/erlang-ipfs-http-client](https://github.com/hendry19901990/erlang-ipfs-http-client) | Inactive |
 | Scheme        | [siiky/ipfs.scm](https://git.sr.ht/~siiky/ipfs.scm) | Active |
 | Lua           | [siiky/ipfs.lua](https://git.sr.ht/~siiky/ipfs.lua) | Active |
+| Elixir        | [bahner/ex-ipfs](https://github.com/bahner/ex-ipfs) | Active |


### PR DESCRIPTION
The referenced library is the core client.

Obviously there is nothing to test with this very simple commit.
