### PR TITLE
chore: update Dockerfile to Go 1.22

### DIFF
--- a/.github/actions/latest-kubo-tag/Dockerfile
+++ b/.github/actions/latest-kubo-tag/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.22
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y jq && rm -rf /var/lib/apt/lists/*

--- a/.github/actions/update-with-latest-versions/Dockerfile
+++ b/.github/actions/update-with-latest-versions/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.22
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y jq && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Updates Dockerfile to match Kubo's latest version.