### PR TITLE
chore: remove mentions of dweb:// URLs

### DIFF
--- a/docs/how-to/address-ipfs-on-web.md
+++ b/docs/how-to/address-ipfs-on-web.md
@@ -287,10 +287,3 @@ Discussions around IPFS addressing have been ongoing since [@jbenet](https://git
 
 It provides support for native URLs and will automatically redirect IPFS gateway requests to your local Kubo daemon so that you are not relying on or trusting remote gateways.
 
-### Shared dWeb namespace
-
-This concept isn't yet built, but may be explored and experimented with in the future. The distributed web community is exploring the idea of a shared `dweb` namespace to remove the complexity of addressing IPFS and other content-addressed protocols. Approaches currently being investigated are:
-
-- `dweb://` protocol handler ([arewedistributedyet/issues/28](https://github.com/arewedistributedyet/arewedistributedyet/issues/28))
-- `.dweb` special-use top-level domain name ([arewedistributedyet/issues/34](https://github.com/arewedistributedyet/arewedistributedyet/issues/34))
-

--- a/docs/install/ipfs-desktop.md
+++ b/docs/install/ipfs-desktop.md
@@ -25,7 +25,7 @@ If you already have an IPFS node on your computer, IPFS Desktop will act as a co
 - **Quick download for CIDs, IPFS paths, and IPNS paths** — choose `Download...` by right-clicking the IPFS icon on your computer's menu bar, paste in a hash, and you're good to go.
 - **Visualize your IPFS peers worldwide** on a map depicting what nodes you're connected to, where they are, the connections they're using, and more.
 - **Explore the "Merkle Forest" of IPFS files** with a visualizer that lets you see firsthand how example datasets stored on IPFS — or your own IPFS files — are broken down into content-addressed pieces.
-- **OS-wide support for IPFS files and links** (on Mac, Windows, and some Linux flavors) automatically hands off links starting with `ipfs://`, `ipns://` and `dweb:` to be opened in IPFS Desktop.
+- **OS-wide support for IPFS files and links** (on Mac, Windows, and some Linux flavors) automatically hands off links starting with `ipfs://` and `ipns://` to be opened in IPFS Desktop.
 - **CLI Tutor Mode** helps you learn IPFS commands as you go.
 
 ### Install instructions


### PR DESCRIPTION
This was aspirational, but other systems did not engage on the idea, mostly due to technical and political limitation of a single piece of software having to act as a router.

Removing it to reduce cofusion. ipfs:// and ipns:// are the way we do things right now, incl. Brave (https://brave.com/ipfs-support/)
