### PR TITLE
fix: remove orphan paragraph

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -15,8 +15,6 @@ Do you want to quickly and easily publish content with IPFS without complex tool
 
 Anyone can use IPFS to store files in a _decentralized_ way. The easiest way to get up and running is by installing the IPFS Desktop application. This app has Kubo built-in and lets you interact with the network through a simple user-interface. [Check it out →](./ipfs-desktop.md)
 
-For long-term storage, users can use the Filecoin network! Filecoin is a peer-to-peer network that stores files on the internet, with built-in economic incentives to ensure files are stored reliably over time. Available storage and pricing are not controlled by any single company. Instead, Filecoin facilitates open markets for storing and retrieving files that anyone can participate in. Learn more over on the [Filecoin docs website.](https://docs.filecoin.io/)
-
 ## IPFS Kubo Node and CLI
 
 Want to build decentralized applications and store your application data on IPFS? You'll likely want to install the command-line version of IPFS. There's no GUI to deal with, just raw input and output through your terminal. [Find out more →](./command-line.md)


### PR DESCRIPTION
It seems this paragraph is a left-over from old version of the page introduced in https://github.com/ipfs/ipfs-docs/commit/10514163a34ee3a9d6e78eeeb9b610bd8d0ed2ab but no longer makes sense, especially in IPFS Desktop section, which has nothing to do with this, especially after [Estuary got shut down](https://github.com/ipfs/ipfs-website/issues/283).

Removing this sentence seems like the best course of action.
