### PR TITLE
chore: /quic → /quic-v1 in examples

### DIFF
--- a/docs/how-to/nat-configuration.md
+++ b/docs/how-to/nat-configuration.md
@@ -89,8 +89,8 @@ In this step, you will update your Kubo configuration to set `Swarm.AppendAnnoun
         "Swarm": [
         "/ip4/0.0.0.0/tcp/4001",
         "/ip6/::/tcp/4001",
-        "/ip4/0.0.0.0/udp/4001/quic",
-        "/ip6/::/udp/4001/quic"
+        "/ip4/0.0.0.0/udp/4001/quic-v1",
+        "/ip6/::/udp/4001/quic-v1"
         ],
         "Announce": [],
         "AppendAnnounce": [],
@@ -105,7 +105,6 @@ In this step, you will update your Kubo configuration to set `Swarm.AppendAnnoun
    ```json
    "AppendAnnounce": [
      "/ip4/<public-ip>/tcp/<port>",
-     "/ip4/<public-ip>/udp/<port>/quic",
      "/ip4/<public-ip>/udp/<port>/quic-v1",
      "/ip4/<public-ip>/udp/<port>/quic-v1/webtransport"
     ],
@@ -116,7 +115,6 @@ In this step, you will update your Kubo configuration to set `Swarm.AppendAnnoun
    ```json
    "AppendAnnounce": [
      "/ip4/1.2.3.4/tcp/12345",
-     "/ip4/1.2.3.4/udp/12345/quic",
      "/ip4/1.2.3.4/udp/12345/quic-v1",
      "/ip4/1.2.3.4/udp/12345/quic-v1/webtransport"
     ],

--- a/docs/how-to/peering-with-content-providers.md
+++ b/docs/how-to/peering-with-content-providers.md
@@ -84,9 +84,9 @@ This list is provided for informational purposes only. The IPFS Project does not
 
 | Peer ID | Addresses |
 | ------- | --------- |
-|`12D3KooWFFhc8fPYnQXdWBCowxSV21EFYin3rU27p3NVgSMjN41k`|`/ip4/5.161.92.43/tcp/4001`<br/>`/ip4/5.161.92.43/udp/4001/quic`<br/>`/ip6/2a01:4ff:f0:3b1e::1/tcp/4001`<br/>`/ip6/2a01:4ff:f0:3b1e::1/udp/4001/quic`|
-|`12D3KooWSW4hoHmDXmY5rW7nCi9XmGTy3foFt72u86jNP53LTNBJ`|`/ip4/5.161.55.227/tcp/4001`<br/>`/ip4/5.161.55.227/udp/4001/quic`<br/>`/ip6/2a01:4ff:f0:1e5a::1/tcp/4001`<br/>`/ip6/2a01:4ff:f0:1e5a::1/udp/4001/quic`|
-|`12D3KooWSDj6JM2JmoHwE9AUUwqAFUEg9ndd3pMA8aF2bkYckZfo`|`/ip4/5.161.92.36/tcp/4001`<br/>`/ip4/5.161.92.36/udp/4001/quic`<br/>`/ip6/2a01:4ff:f0:3764::1/tcp/4001`<br/>`/ip6/2a01:4ff:f0:3764::1/udp/4001/quic`|
+|`12D3KooWFFhc8fPYnQXdWBCowxSV21EFYin3rU27p3NVgSMjN41k`|`/ip4/5.161.92.43/tcp/4001`<br/>`/ip4/5.161.92.43/udp/4001/quic-v1`<br/>`/ip6/2a01:4ff:f0:3b1e::1/tcp/4001`<br/>`/ip6/2a01:4ff:f0:3b1e::1/udp/4001/quic-v1`|
+|`12D3KooWSW4hoHmDXmY5rW7nCi9XmGTy3foFt72u86jNP53LTNBJ`|`/ip4/5.161.55.227/tcp/4001`<br/>`/ip4/5.161.55.227/udp/4001/quic-v1`<br/>`/ip6/2a01:4ff:f0:1e5a::1/tcp/4001`<br/>`/ip6/2a01:4ff:f0:1e5a::1/udp/4001/quic-v1`|
+|`12D3KooWSDj6JM2JmoHwE9AUUwqAFUEg9ndd3pMA8aF2bkYckZfo`|`/ip4/5.161.92.36/tcp/4001`<br/>`/ip4/5.161.92.36/udp/4001/quic-v1`<br/>`/ip6/2a01:4ff:f0:3764::1/tcp/4001`<br/>`/ip6/2a01:4ff:f0:3764::1/udp/4001/quic-v1`|
 
 ### bit.site
 

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -50,15 +50,15 @@ The first thing to do is to double-check that both nodes are, in fact, running a
 
 ```json
 {
-    "ID": "QmTNwsFkLAed15kQEC1ZJWPfoNbBQnMFojfJKQ9sZj1dk8",
-        "PublicKey": "CAASpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDZb6znj3LQZKP1+X81exf+vbnqNCMtHjZ5RKTCm7Fytnfe+AI1fhs9YbZdkgFkM1HLxmIOLQj2bMXPIGxUM+EnewN8tWurx4B3+lR/LWNwNYcCFL+jF2ltc6SE6BC8kMLEZd4zidOLPZ8lIRpd0x3qmsjhGefuRwrKeKlR4tQ3C76ziOms47uLdiVVkl5LyJ5+mn4rXOjNKt/oy2O4m1St7X7/yNt8qQgYsPfe/hCOywxCEIHEkqmil+vn7bu4RpAtsUzCcBDoLUIWuU3i6qfytD05hP8Clo+at+l//ctjMxylf3IQ5qyP+yfvazk+WHcsB0tWueEmiU5P2nfUUIR3AgMBAAE=",
+    "ID": "12D3KooWRaeAw2oromYUN5rAjYQ6KhqvXiWg8KuxeU9YWv7v3Ewa",
+        "PublicKey": "CAASp[...]P2nfUUIR3AgMBAAE=",
         "Addresses": [
-            "/ip4/127.0.0.1/tcp/4001/p2p/QmTNwsFkLAed15kQEC1ZJWPfoNbBQnMFojfJKQ9sZj1dk8",
-        "/ip4/127.0.0.1/udp/4001/quic/p2p/QmTNwsFkLAed15kQEC1ZJWPfoNbBQnMFojfJKQ9sZj1dk8",
-        "/ip4/192.168.2.131/tcp/4001/p2p/QmTNwsFkLAed15kQEC1ZJWPfoNbBQnMFojfJKQ9sZj1dk8",
-        "/ip4/192.168.2.131/udp/4001/quic/p2p/QmTNwsFkLAed15kQEC1ZJWPfoNbBQnMFojfJKQ9sZj1dk8"
+            "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooWRaeAw2oromYUN5rAjYQ6KhqvXiWg8KuxeU9YWv7v3Ewa",
+            "/ip4/127.0.0.1/udp/4001/quic-v1/p2p/12D3KooWRaeAw2oromYUN5rAjYQ6KhqvXiWg8KuxeU9YWv7v3Ewa",
+            "/ip4/192.168.2.131/tcp/4001/p2p/12D3KooWRaeAw2oromYUN5rAjYQ6KhqvXiWg8KuxeU9YWv7v3Ewa",
+            "/ip4/192.168.2.131/udp/4001/quic-v1/p2p/12D3KooWRaeAw2oromYUN5rAjYQ6KhqvXiWg8KuxeU9YWv7v3Ewa"
         ],
-       "AgentVersion": "kubo/0.4.11-dev/",
+       "AgentVersion": "kubo/0.29.0-dev/",
         "ProtocolVersion": "ipfs/0.1.0"
 }
 ```
@@ -75,11 +75,11 @@ In the case where `node b` simply cannot form a connection to `node a`, despite 
 
 ```shell
 /ip4/127.0.0.1/tcp/4001
-/ip4/127.0.0.1/udp/4001/quic
+/ip4/127.0.0.1/udp/4001/quic-v1
 /ip4/192.168.2.133/tcp/4001
-/ip4/192.168.2.133/udp/4001/quic
+/ip4/192.168.2.133/udp/4001/quic-v1
 /ip4/88.157.217.196/tcp/63674
-/ip4/88.157.217.196/udp/63674/quic
+/ip4/88.157.217.196/udp/63674/quic-v1
 ```
 
 In this case, we can see a localhost (127.0.0.1) address, a LAN address (the 192.168._._ one), and another address. If this third address matches your external IP, then the network knows a valid external address for your node. At this point, it's safe to assume that your node has a difficult to traverse NAT situation. If this is the case, you can try to enable UPnP or NAT-PMP on the router of `node a` and retry the process. Otherwise, you can try manually connecting `node a` to `node b`.


### PR DESCRIPTION
Fixing some leftovers, I've seen people on forums still following outdated nat configuration tutorial.

Ref. 
- https://github.com/libp2p/go-libp2p/issues/2369
- https://discuss.ipfs.tech/t/getting-a-public-ip-behind-nat/18212/3?u=lidel