### PR TITLE
fix: match documentation with ipfs desktop button label

### DIFF
--- a/docs/how-to/websites-on-ipfs/single-page-website.md
+++ b/docs/how-to/websites-on-ipfs/single-page-website.md
@@ -188,7 +188,7 @@ The next step is to import your site into IPFS using the IPFS desktop app you ju
    ```
 
 2. Open IPFS desktop and go to the **Files** page.
-3. Click **Add** → **File**.
+3. Click **+Import** → **File**.
 4. Navigate to your `index.html` file and select **Open**.
 
    ![Choose a file window open in IPFS desktop.](./images/single-page-website/add-ipfs-desktop-open-file.png)

--- a/docs/how-to/websites-on-ipfs/single-page-website.md
+++ b/docs/how-to/websites-on-ipfs/single-page-website.md
@@ -255,7 +255,6 @@ Domain name services are fairly slow to update. You should be able to go to your
 ## Up next
 
 This project was designed to get you up and running quickly, but there are many improvements we can make here.
-
-You may have noticed that when visiting [randomplanetfacts.xyz](http://randomplanetfacts.xyz), your browser redirects to [gateway.pinata.cloud/ipfs/QmW7S5HR...](https://gateway.pinata.cloud/ipfs/QmW7S5HRLkP4XtPNyT1vQSjP3eRdtZaVtF6FAPvUfduMjA). This isn't great for the user's experience, and it can cause issues with security certificates and other website validation methods. Also, this website is incredibly simple. There are no images, external stylesheets, or javascript files. 
+ 
 If you're interested in building a more complex site using IPFS and securing it properly, [carry on with this tutorial series by hosting a multipage website on IPFS.](multipage-website.md)
 


### PR DESCRIPTION
# Describe your changes
Just a language match between what's in IPFS desktop app and the documentation

# Files changed
- docs/how-to/websites-on-ipfs/single-page-website.md

# What issue(s) does this address?
- good documentation

# Does this update depend on any other PRs?
- not from what I can tell

## Checklist before requesting a review
- [✅ ] Passing the beta version of the **Check Markdown links for modified files** check. Action results can be viewed [here](https://github.com/ipfs/ipfs-docs/actions/workflows/action.yml).

## Checklist before merging
- [ ✅] Passing all required checks (The beta **Check Markdown links for modified files** check is not required)
