### PR TITLE
chore: brave cleanup + updated links

### DIFF
--- a/.github/styles/pln-ignore.txt
+++ b/.github/styles/pln-ignore.txt
@@ -205,6 +205,7 @@ sneakernets
 stackparse
 stdout
 storj
+Someguy
 subcommand
 substring
 sys

--- a/docs/concepts/ipfs-implementations.md
+++ b/docs/concepts/ipfs-implementations.md
@@ -9,29 +9,31 @@ IPFS is an open-source project that encourages the development of multiple imple
 
 You can learn more about the principles that define what an IPFS implementation is [here](./implementations.md).
 
-::: tip
-Looking for an easy, user-friendly way to get started with IPFS? Try any of the options listed below:
+::: callout TLDR
+Looking for an easy, user-friendly way to get started with IPFS?
+Try any of the options listed below:
 
-- [IPFS Desktop](../install/ipfs-desktop.md), a single application that bundles an IPFS Kubo node, file manager, peer manager, and content explorer.
-- [Brave Browser](../how-to/companion-node-types.md#native), native support for IPFS in a browser with a Kubo node built directly into the browser itself.
+- [IPFS Desktop](../install/ipfs-desktop.md), an user-friendly GUI application that bundles an IPFS Kubo node, file manager, peer manager, and content explorer.
+- [IPFS Companion](../install/ipfs-companion.md), a browser extension that compliments IPFS Desktop, loads compatible websites and file paths from a local IPFS Kubo node.
+- [IPFS Kubo](../install/command-line.md), standalone demon service with command-line and HTTP RPC interface for power users who don't need GUI.
   :::
 
 ## Popular or Actively Maintained
 
 | Name            | URL                                                | Language(s)            | What it's trying to do                                                                          |
 | --------------- | -------------------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------- |
-| bifrost-gateway | <https://github.com/ipfs/bifrost-gateway>          | go                     | Lightweight IPFS HTTP Gateway daemon backed by a remote data store.                             |
-| boost           | <https://github.com/filecoin-project/boost>        | go                     | Daemon to get IPFS data in and out of a Filecoin storage provider.                              |
-| boxo            | <https://github.com/ipfs/boxo>                     | go                     | A component library for building IPFS applications and implementations in Go.                   |
+| Boost           | <https://github.com/filecoin-project/boost>        | go                     | Daemon to get IPFS data in and out of a Filecoin storage provider.                              |
+| Boxo (GO SDK)   | <https://github.com/ipfs/boxo>                     | go                     | A component library for building IPFS applications and implementations in Go.                   |
 | Elastic IPFS    | <https://github.com/elastic-ipfs/elastic-ipfs>     | javascript, typescript | Scalable cloud-native implementation.                                                           |
-| Estuary         | <https://github.com/application-research/estuary/> | go                     | Daemon oriented service to pin and onboard IPFS data into Filecoin.                             |
-| helia           | <https://github.com/ipfs/helia>                    | javascript             | A lean, modular, and modern implementation of IPFS for the prolific JS and browser environments |
-| ipfs cluster    | <https://github.com/ipfs/ipfs-cluster>             | go                     | Orchestration for multiple Kubo nodes via CRDT / Raft consensus                                 |
-| iroh            | <https://github.com/n0-computer/iroh>              | rust                   | Extreme-efficiency oriented IPFS implementation.                                                |
+| Helia (JS SDK)  | <https://github.com/ipfs/helia>                    | javascript             | A lean, modular, and modern implementation of IPFS for the prolific JS and browser environments |
+| IPFS Cluster    | <https://github.com/ipfs/ipfs-cluster>             | go                     | Orchestration for multiple Kubo nodes via CRDT / Raft consensus                                 |
+| Iroh            | <https://github.com/n0-computer/iroh>              | rust                   | Extreme-efficiency oriented IPFS implementation.                                                |
 | Kubo            | <https://github.com/ipfs/kubo>                     | go                     | Generalist daemon oriented IPFS implementation with an extensive HTTP RPC API.                  |
 | Lassie          | <https://github.com/filecoin-project/lassie/>      | go                     | A minimal universal retrieval client library for IPFS and Filecoin.                             |
 | Lotus           | <https://github.com/filecoin-project/lotus>        | go                     | Filecoin node handling consensus, storage providing, making storage deals, importing data, ...  |
 | Nabu            | <https://github.com/peergos/nabu>                  | java                   | A minimalistic, fast and embeddable IPFS implementation.                                        |
+| Rainbow         | <https://github.com/ipfs/rainbow/>                 | go                     | A specialized IPFS HTTP gateway implementation.                                                 |
+| Someguy         | <https://github.com/ipfs/someguy/>                 | go                     | A Delegated Routing V1 server and client for all your HTTP/IPFS routing needs.                  |
 
 ## Lite or Experimental
 
@@ -53,6 +55,7 @@ Looking for an easy, user-friendly way to get started with IPFS? Try any of the 
 | ---------- | ----------------------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | Agregore   | <https://github.com/AgregoreWeb/agregore-ipfs-daemon> | go, javascript         | Mobile friendly Kubo daemon.                                                                                                              |
 | c-ipfs     | <https://git.agorise.net/agorise/c-ipfs>              | C                      | IPFS implementation in C.                                                                                                                 |
+| Estuary    | <https://github.com/application-research/estuary/>    | go                     | Daemon oriented service to pin and onboard IPFS data into Filecoin.                                                                       |
 | ipfs tiny  | <https://gitlab.com/librespacefoundation/ipfs-tiny>   | c++                    | Tiny embeddable, os-independent IPFS implementation.                                                                                      |
 | ipget      | <https://github.com/ipfs/ipget>                       | go                     | Minimal wget inspired tool to download files from IPFS nodes over bitswap.                                                                |
 | js-ipfs    | <https://github.com/ipfs/js-ipfs>                     | javascript, typescript | Javascript implementation targeting nodejs and browsers. [Deprecated and replaced by Helia](https://github.com/ipfs/js-ipfs/issues/4336). |

--- a/docs/how-to/address-ipfs-on-web.md
+++ b/docs/how-to/address-ipfs-on-web.md
@@ -66,7 +66,6 @@ IPFS clients, user agents, tools and extensions should detect CIDs in URLs, DNSL
 
 Examples of user agents that support IPFS natively are:
 
-- [Brave](https://brave.com/ipfs-support/)
 - A standard web browser with [IPFS Companion](https://docs.ipfs.tech/install/ipfs-companion/) installed next to an IPFS node, such as [IPFS Desktop](https://docs.ipfs.tech/install/ipfs-desktop/)
 
 ## Path gateway
@@ -138,15 +137,6 @@ https://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq.ipfs.dweb.li
 http://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq.ipfs.localhost:8080/wiki/Vincent_van_Gogh.html
 ```
 
-#### Native support in Kubo
-
-[Kubo](https://dist.ipfs.tech/#kubo) provides native support for subdomain gateways on hostnames defined in the [`Gateway.PublicGateways`](https://github.com/ipfs/kubo/blob/master/docs/config.md#gatewaypublicgateways) configuration map.
-
-Learn more about Kubo configuration for hosting a public gateway:
-
-- [`Gateway.PublicGateways`](https://github.com/ipfs/kubo/blob/master/docs/config.md#gatewaypublicgateways) for defining gateway behavior on specified hostnames
-- [`Gateway` recipes](https://github.com/ipfs/kubo/blob/master/docs/config.md#gateway-recipes) with ready to use one-liners for most common use cases
-
 ::: warning Known issues
 
 1. Some browsers and other user agents force lowercase for the authority part of URLs, breaking case-sensitive CIDs before the HTTP gateway has a chance to read them.
@@ -158,6 +148,12 @@ Base32 is the safe default; the less-popular Base36 can be used for longer ED255
 See the next section to learn how to convert an existing CIDv0 to a DNS-safe representation.
 
 :::
+
+#### Native support in Kubo and Rainbow
+
+[Kubo](https://dist.ipfs.tech/#kubo) provides native support for subdomain gateway, see  [`Gateway` recipes](https://github.com/ipfs/kubo/blob/master/docs/config.md#gateway-recipes) with ready to use one-liners for most common use cases.
+
+If you need a high-performance HTTP gateway, you may want to deploy [Rainbow](https://github.com/ipfs/rainbow/) instead. Rainbow is a specialized IPFS HTTP gateway which makes it easier to scale HTTP retrieval and isolate it from your Bitswap provider backend, such as Kubo or IPFS Cluster. See `rainbow --help` for relevant configuration (`--subdomain-gateway-domains` and `RAINBOW_SUBDOMAIN_GATEWAY_DOMAINS`).
 
 #### CID conversion for subdomains
 

--- a/docs/how-to/best-practices-for-nft-data.md
+++ b/docs/how-to/best-practices-for-nft-data.md
@@ -12,8 +12,6 @@ Since an NFT can't be easily changed after it's been created, it's a good idea t
 
 This guide is aimed at developers building NFT platforms and other tools, and it's focused on how to format your data and link to it for the best long-term results. 
 
-If you're interested in a deeper dive in the world of NFT best practices and NFT development in general, head over to [NFT School](https://nftschool.dev) for concept guides, tutorials, and how-tos.
-
 ## Types of IPFS links and when to use them
 
 There are a few different ways to refer to data on IPFS, each of which is best suited to different use cases.

--- a/docs/how-to/best-practices-for-nft-data.md
+++ b/docs/how-to/best-practices-for-nft-data.md
@@ -28,7 +28,7 @@ bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
 
 There are two versions of CIDs used by IPFS. The example above is a version 1 CID (or CIDv1), and it has some advantages over the older "version 0" format, especially when viewing IPFS content on the web using an IPFS gateway. It's best to use version 1 CIDs for addressing NFT data, in the base32 encoding.
 
-To enable CIDv1 when using the IPFS command line, add the `--cid-version=1` flag when running the `ipfs add` command:
+To enable CIDv1 when using the [IPFS command line provided by Kubo](../install/command-line.md), add the `--cid-version=1` flag when running the `ipfs add` command:
 
 ```shell
 ipfs add --cid-version=1 ~/no-time-to-explain.jpeg
@@ -44,7 +44,7 @@ const cid = await ipfs.add({ content }, {
 })
 ```
 
-If you already have a version 0 CID for your content, there's no need to add it to IPFS again just to get the new CID format! You can convert a v0 CID to v1 using [the ipfs command line](address-ipfs-on-web.md#manual-use-cid-ipfs-io-or-the-command-line) or on the web at [cid.ipfs.io](https://cid.ipfs.io). If you're not sure which version you have, it's easy to tell the difference. Version 0 CIDs are always 46 characters long, starting with `Qm`.
+If you already have a version 0 CID for your content, there's no need to add it to IPFS again just to get the new CID format! You can convert a v0 CID to v1 using [the ipfs command line](address-ipfs-on-web.md#manual-use-cid-ipfs-io-or-the-command-line) or on the web at [cid.ipfs.tech](https://cid.ipfs.tech). If you're not sure which version you have, it's easy to tell the difference. Version 0 CIDs are always 46 characters long, starting with `Qm`.
 
 ::: tip
 You can learn more about CIDs in our [guide to Content Addressing][docs-cid], or by following the [interactive tutorials on ProtoSchool][protoschool-cid].
@@ -74,7 +74,7 @@ HTTP gateways provide interoperability for legacy user-agents that cannot resolv
 
 Here's an example: `https://dweb.link/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi`
 
-User agents with built-in support for IPFS (either via the IPFS Companion browser extension, or via native support, such as provided by Brave) will be able to recognize gateway links and resolve the content using native IPFS protocols. Other user-agents will simply follow the link to the gateway, which will load the content over IPFS and serve it using HTTP. You can learn more details about HTTP gateways in our [concept article on IPFS Gateway][docs-gateway].
+User agents with built-in support for IPFS (either via the [IPFS Companion browser extension](../install/ipfs-companion.md), or via native support) will be able to recognize gateway links and resolve the content using native IPFS protocols. Other user-agents will simply follow the link to the gateway, which will load the content over IPFS and serve it using HTTP. You can learn more details about HTTP gateways in our [concept article on IPFS Gateway][docs-gateway].
 
 Gateway links are great for interoperability, but they should not be the primary or canonical link to your data on IPFS. While an IPFS URI will remain accessible as long as anyone on IPFS has the data, a gateway link can fail if the gateway operator goes offline. 
 

--- a/docs/how-to/companion-node-types.md
+++ b/docs/how-to/companion-node-types.md
@@ -5,14 +5,13 @@ description: Learn about the available node types in IPFS Companion.
 
 # Understand node types in IPFS Companion
 
-IPFS Companion's preferences screen allows you to choose from different node types. The available types you'll see in your Companion preferences depends on the browser you're using (i.e. Firefox, Chrome, Brave), but the full list is as follows:
+IPFS Companion's preferences screen allows you to choose from different node types. The available types you'll see in your Companion preferences depends on the browser you're using (i.e. Firefox, Chrome), but the full list is as follows:
 
 [[toc]]
 
 **If you're already running a local IPFS node, choose _External_.** If not, do one of the following:
 
 - [Install](../install/README.md) and run IPFS as an [external node](#external) (recommended).
-- Use a [native node](#native) built into your browser (Brave v1.19 or later only).
 
 ## External
 
@@ -21,7 +20,7 @@ An _external_ node can be any instance of an IPFS daemon that:
 - Runs outside of your web browser.
 - Exposes a _gateway_ and writeable _API_ over HTTP at TCP ports.
 
-The [Kubo](https://github.com/ipfs/kubo) implementation of IPFS is the recommended choice for running an external IPFS node. It's less power-hungry than other implementations and uses the `dhtclient` mode to decrease ambient bandwidth use and reduce battery drain.
+The [Kubo](https://github.com/ipfs/kubo) implementation of IPFS is the recommended choice for running an external IPFS node. It's less power-hungry than other implementations and can use the `autoclient` mode to decrease ambient DHT traffic and reduce battery drain.
 
 A good practice is to run your Kubo daemon on localhost (`127.0.0.1`), as it provides:
 
@@ -35,30 +34,3 @@ You can get started with running a Kubo node on your local machine in several wa
 - If you're comfortable with the command line and don't need the convenience of the IPFS Desktop UI, follow the directions in the [command line quick-start guide](command-line-quick-start.md).
 - Docker fans can run and use Kubo from [inside a Docker container](https://github.com/ipfs/kubo#running-ipfs-inside-docker).
 
-## Native
-
-### Provided by Brave
-
-Users of the [Brave](https://brave.com/) browser (v1.19 or later) can enable native support for IPFS using a Kubo node built directly into the browser itself. This is a great way to experiment with IPFS without having to install or run IPFS Desktop or the command-line daemon.
-
-This node type offers the same benefits as an [external](#external) node, with additional features provided within Brave itself:
-
-- Native support for `ipfs://` and `ipns://` URIs:
-  - Built-in fallback to a public gateway.
-  - Ability to change your preferred public gateway from Brave's settings page.
-  - Options for default resolution of IPFS resources: through a public gateway, through a local node, or asking each time.
-- The IPFS node is managed by Brave itself:
-  - Automatic Kubo updates and migrations.
-  - Your node is only running when Brave is open.
-  - You can start/stop your Brave-based node by clicking the power button icon in IPFS Companion's main menu.
-
-::: tip TOOLS FOR BRAVE USERS
-
-- `ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi`
-  Popular URI for triggering and testing native IPFS support
-- `brave://settings/extensions`
-  One-click Companion install and URI resolution settings
-- `brave://ipfs`
-  Status page for Brave's built-in Kubo node
-
-:::

--- a/docs/how-to/companion-x-ipfs-path-header.md
+++ b/docs/how-to/companion-x-ipfs-path-header.md
@@ -7,7 +7,7 @@ description: Learn more about how to use "x-ipfs-path" headers in IPFS Companion
 
 IPFS Companion can redirect traditional HTTP requests to IPFS if the `x-ipfs-path` response header is provided.
 
-Additionally, some browser vendors like [Brave](https://brave.com/ipfs-support/) may display an **Open using IPFS** button on the address bar when this header is returned for the root document in the current tab.
+Additionally, some browser vendors may display an **Open using IPFS** button on the address bar when this header is returned for the root document in the current tab.
 
 ## Overview
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -33,4 +33,4 @@ Planning to set up several Kubo nodes within one network? You'll want to take a 
 
 ## IPFS Companion Browser Extension
 
-Some browsers such as [Brave](https://brave.com/) and [Opera](https://www.opera.com/) come with IPFS built-in. If your browser doesn't support IPFS yet, you can install an IPFS companion extension that will let you view decentralized web content! [Learn more →](./ipfs-companion.md)
+If your browser doesn't support IPFS yet, you can install an IPFS companion extension that will let you view decentralized web content! [Learn more →](./ipfs-companion.md)

--- a/docs/install/command-line.md
+++ b/docs/install/command-line.md
@@ -334,7 +334,7 @@ The local daemon process is automatically started in the CLI with the command `i
 
 ### Remote client
 
-You can install the standalone IPFS CLI client independently and use it to talk to an IPFS Desktop node or a Brave node. Use the [RPC API](../reference/kubo/rpc.md#http-rpc-api-reference) to talk to the `ipfs` daemon.
+You can install the standalone IPFS CLI client independently and use it to talk to an IPFS Desktop (Kubo) node. Use the [RPC API](../reference/kubo/rpc.md#http-rpc-api-reference) to talk to the `ipfs` daemon.
 
 When an IPFS command executes without parameters, the CLI client checks whether the `$IPFS_PATH/api` file exists and connects to the address listed there.
 
@@ -348,7 +348,7 @@ If you are an IPFS Desktop user, you can install CLI tools and an `.ipfs/api` fi
 
 If you're not running IPFS Desktop, specify a custom port with `ipfs --api /ip4/127.0.0.1/tcp/<port> id` in the CLI.
 
-For example, Brave RPC API runs on port 45001, so the CLI can talk to the Brave daemon using `ipfs --api /ip4/127.0.0.1/tcp/45001 id`. You can use `mkdir -p ~/.ipfs && echo "/ip4/<ip>/tcp/<rpc-port>" > ~/.ipfs/api` to avoid passing `--api` every time.
+You can use `mkdir -p ~/.ipfs && echo "/ip4/<ip>/tcp/<rpc-port>" > ~/.ipfs/api` to avoid passing `--api` every time.
 
 ## Next steps
 


### PR DESCRIPTION
Removed mentions of "Brave support" and updated some outdated content I noticed.

Context: https://blog.ipfs.tech/2024-brave-migration-guide/ cc @2color 
