### PR TITLE
feat: cleaned up `/install` landing

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -5,13 +5,16 @@ const SPEEDCURVE_ID = process.env.SPEEDCURVE_ID || ''
 const pageSuffix = '/'
 
 const installMenuChildren = [
-  ['/install/command-line','IPFS Kubo for Go'],
-  ['/install/run-ipfs-inside-docker', 'IPFS Kubo in Docker'],
-  ['https://github.com/ipfs/helia','IPFS Helia for JavaScript'],
-  ['https://iroh.computer/docs/install/', "IPFS Iroh for Rust"],
   ['/install/ipfs-desktop', 'IPFS Desktop App'],
   ['/install/ipfs-companion', 'IPFS Companion Browser Extension'],
-  ['/install/server-infrastructure', 'IPFS Cluster']
+  ['/install/command-line','Kubo Daemon & CLI'],
+  ['/install/run-ipfs-inside-docker', 'Kubo in Docker'],
+  ['/install/server-infrastructure', 'IPFS Cluster'],
+  ['https://github.com/ipfs/rainbow#readme', 'Rainbow Gateway'],
+  ['https://github.com/ipfs/someguy#readme', 'Someguy Delegated Router'],
+  ['https://github.com/ipfs/helia#readme','Helia SDK for JS'],
+  ['https://github.com/ipfs/boxo#readme','Boxo SDK for Go'],
+  ['/concepts/ipfs-implementations','Other Implementations']
 ]
 
 module.exports = {

--- a/docs/concepts/ipfs-implementations.md
+++ b/docs/concepts/ipfs-implementations.md
@@ -9,14 +9,20 @@ IPFS is an open-source project that encourages the development of multiple imple
 
 You can learn more about the principles that define what an IPFS implementation is [here](./implementations.md).
 
-::: callout TLDR
-Looking for an easy, user-friendly way to get started with IPFS?
-Try any of the options listed below:
 
-- [IPFS Desktop](../install/ipfs-desktop.md), an user-friendly GUI application that bundles an IPFS Kubo node, file manager, peer manager, and content explorer.
-- [IPFS Companion](../install/ipfs-companion.md), a browser extension that compliments IPFS Desktop, loads compatible websites and file paths from a local IPFS Kubo node.
-- [IPFS Kubo](../install/command-line.md), standalone demon service with command-line and HTTP RPC interface for power users who don't need GUI.
-  :::
+::: callout Mainnet TLDR
+
+Looking for an easy and opinionated way to get started with IPFS [Mainnet](../concepts/glossary.md#mainnet)?
+
+**User-Friendly Options**
+  - [IPFS Desktop](../install/ipfs-desktop.md), an user-friendly GUI application that bundles an IPFS Kubo node for self-hosting, file manager, peer manager, and content explorer.
+  - [IPFS Companion](../install/ipfs-companion.md), a browser extension that compliments IPFS Desktop, loads compatible websites and file paths from a local IPFS Kubo node.
+
+**Command-Line & Infrastructure Tools**
+  - [Kubo](../install/command-line.md), all-in-one demon service with command-line and HTTP RPC interface for power users who want to self-host, but don't need GUI.
+  - [IPFS Cluster](../install/server-infrastructure.md), data orchestration across a swarm of IPFS daemons by allocating, replicating and tracking a global pinset distributed among multiple peers.
+  - [Rainbow](https://github.com/ipfs/rainbow/#readme), production-grade standalone IPFS HTTP [Gateway](../concepts/glossary.md#gateway) service powering [public gateways](../concepts/public-utilities.md#public-ipfs-gateways).
+:::
 
 ## Popular or Actively Maintained
 

--- a/docs/concepts/ipfs-implementations.md
+++ b/docs/concepts/ipfs-implementations.md
@@ -20,7 +20,7 @@ Looking for an easy and opinionated way to get started with IPFS?
 
 **Command-Line & Infrastructure Tools**
   - [Kubo](../install/command-line.md), all-in-one demon service with command-line and HTTP RPC interface for power users who want to self-host, but don't need GUI.
-  - [IPFS Cluster](../install/server-infrastructure.md), data orchestration across a swarm of IPFS daemons by allocating, replicating and tracking a global pinset distributed among multiple peers.
+  - [IPFS Cluster](../install/server-infrastructure.md), data orchestration across a swarm of IPFS Kubo daemons by allocating, replicating and tracking a global pinset distributed among multiple peers.
   - [Rainbow](https://github.com/ipfs/rainbow/#readme), production-grade standalone IPFS HTTP [Gateway](../concepts/glossary.md#gateway) service powering [public gateways](../concepts/public-utilities.md#public-ipfs-gateways).
 :::
 

--- a/docs/concepts/ipfs-implementations.md
+++ b/docs/concepts/ipfs-implementations.md
@@ -10,9 +10,9 @@ IPFS is an open-source project that encourages the development of multiple imple
 You can learn more about the principles that define what an IPFS implementation is [here](./implementations.md).
 
 
-::: callout Mainnet TLDR
+::: callout TLDR
 
-Looking for an easy and opinionated way to get started with IPFS [Mainnet](../concepts/glossary.md#mainnet)?
+Looking for an easy and opinionated way to get started with IPFS?
 
 **User-Friendly Options**
   - [IPFS Desktop](../install/ipfs-desktop.md), an user-friendly GUI application that bundles an IPFS Kubo node for self-hosting, file manager, peer manager, and content explorer.

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -23,7 +23,7 @@ If your browser doesn't support IPFS yet, you can install an IPFS companion exte
 
 Do you want to quickly and easily publish content with IPFS without complex tools? See the [Publish with IPFS quickstart](../quickstart/publish.md), where you'll learn how to use third-party pinning services to pin and provide files to the IPFS network.
 
-## Command-Line & Infrastructure Tools
+## Infrastructure Tools
 
 ### Kubo
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -7,30 +7,54 @@ description: There are several different ways you can install and interact with 
 
 IPFS is a collection of protocols, packages, and specifications that allow computers to send and receive data. Because of this, users can interact with and use IPFS in many different ways. A developer building network applications will use a different set of tools to interact with IPFS than someone who wants to store files on IPFS. Pick the one that best suits what you're here to do.
 
-## Publish files with a pinning service
+Looking for an easy and opinionated way to get started with IPFS [Mainnet](../concepts/glossary.md#mainnet)? Try any of the options listed below:
 
-Do you want to quickly and easily publish content with IPFS without complex tools? See the [Publish with IPFS quickstart](../quickstart/publish.md), where you'll learn how to use pinning services to pin files to the IPFS network.
+## User-Friendly Options
 
-## IPFS Desktop
+### IPFS Desktop
 
 Anyone can use IPFS to store files in a _decentralized_ way. The easiest way to get up and running is by installing the IPFS Desktop application. This app has Kubo built-in and lets you interact with the network through a simple user-interface. [Check it out →](./ipfs-desktop.md)
 
-## IPFS Kubo Node and CLI
+### IPFS Companion
 
-Want to build decentralized applications and store your application data on IPFS? You'll likely want to install the command-line version of IPFS. There's no GUI to deal with, just raw input and output through your terminal. [Find out more →](./command-line.md)
+If your browser doesn't support IPFS yet, you can install an IPFS companion extension that will let you view decentralized web content! [Learn more →](./ipfs-companion.md)
 
-## IPFS Helia for JS
+### Publish files with a pinning service
+
+Do you want to quickly and easily publish content with IPFS without complex tools? See the [Publish with IPFS quickstart](../quickstart/publish.md), where you'll learn how to use third-party pinning services to pin and provide files to the IPFS network.
+
+## Command-Line & Infrastructure Tools
+
+### Kubo
+
+Want to build decentralized applications and store your application data on IPFS? You'll likely want to install the command-line version of IPFS named Kubo. There's no GUI to deal with, just raw input and output through your terminal. [Find out more →](./command-line.md)
+
+### IPFS Cluster
+
+Planning to set up several Kubo nodes within one network? You'll want to take a look at installing [IPFS Cluster](./server-infrastructure.md), which provides data orchestration across a swarm of IPFS daemons by allocating, replicating and tracking a global pinset distributed among multiple peers.
+
+### Rainbow
+
+If you only want to run production-grade HTTP [Gateway](../concepts/glossary.md#gateway) service using the same software that is powering [public gateways](../concepts/public-utilities.md#public-ipfs-gateways), you may want to choose [Rainbow →](https://github.com/ipfs/rainbow/#readme).
+
+### Someguy
+
+If you need to run your own [delegated routing](../concepts/glossary.md#delegated-routing) endpoint that hits both Amino DHT and IPNI, consider running [Someguy →](https://github.com/ipfs/someguy/#readme).
+
+## Software Development
+
+### Helia SDK for JS
 
 [Helia](https://github.com/ipfs/helia) is a new implementation of IPFS in JavaScript that is designed to be more modular and lightweight than the [deprecated js-ipfs project](https://github.com/ipfs/js-ipfs).
 
 To get started with a hands-on example, see [Helia 101](https://github.com/ipfs-examples/helia-examples/blob/main/examples/helia-101/README.md) in [ipfs-examples/helia-examples](https://github.com/ipfs-examples/helia-examples/tree/main).
 
+:::callout
 If you are looking for simple [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)-like API for use on the web, see [@helia/verified-fetch](https://www.npmjs.com/package/@helia/verified-fetch).
+:::
 
-## IPFS Cluster
+### Boxo SDK for GO
 
-Planning to set up several Kubo nodes within one network? You'll want to take a look at installing [IPFS Cluster →](./server-infrastructure.md)
+[Boxo](https://github.com/ipfs/boxo#readme) is a set of reference libraries for building IPFS applications and implementations in Go.
 
-## IPFS Companion Browser Extension
-
-If your browser doesn't support IPFS yet, you can install an IPFS companion extension that will let you view decentralized web content! [Learn more →](./ipfs-companion.md)
+To get started, see [boxo/examples](https://github.com/ipfs/boxo/tree/main/examples) or inspect how Boxo is used in [Kubo](https://github.com/ipfs/kubo), [Rainbow](https://github.com/ipfs/rainbow/), [Someguy](https://github.com/ipfs/someguy), [IPFS Cluster](https://github.com/ipfs-cluster/ipfs-cluster/), or non-Mainnet implementations like [Lotus](https://github.com/filecoin-project/lotus/).

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -13,7 +13,7 @@ Looking for an easy and opinionated way to get started with IPFS [Mainnet](../co
 
 ### IPFS Desktop
 
-Anyone can use IPFS to store files in a _decentralized_ way. The easiest way to get up and running is by installing the IPFS Desktop application. This app has Kubo built-in and lets you interact with the network through a simple user-interface. [Check it out →](./ipfs-desktop.md)
+Anyone can use IPFS to store files in a _decentralized_ way. The easiest way to get up and running is by installing the IPFS Desktop application. This app has a Kubo node built-in and lets you interact with the network through a simple user interface. [Check it out →](./ipfs-desktop.md)
 
 ### IPFS Companion
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -9,7 +9,7 @@ IPFS is a collection of protocols, packages, and specifications that allow compu
 
 Looking for an easy and opinionated way to get started with IPFS [Mainnet](../concepts/glossary.md#mainnet)? Try any of the options listed below:
 
-## User-Friendly Options
+## Desktop Users
 
 ### IPFS Desktop
 

--- a/docs/install/server-infrastructure.md
+++ b/docs/install/server-infrastructure.md
@@ -6,7 +6,7 @@ current-ipfs-cluster-version: v1.1.1
 
 # Set up server infrastructure with IPFS Cluster
 
-If you want to install IPFS in a server environment and offer IPFS as a service, you should look at [IPFS Cluster](https://cluster.ipfs.io/) as a way to scale your IPFS deployment beyond a single IPFS daemon. IPFS Cluster provides data orchestration across a swarm of IPFS daemons by allocating, replicating, and tracking a global pin-set distributed among multiple peers. This makes it significantly easier to manage multiple IPFS nodes and ensure that data is available across an internal network.
+If you want to install IPFS in a server environment and offer IPFS as a service, you should look at [IPFS Cluster](https://ipfscluster.io/) as a way to scale your IPFS deployment beyond a single IPFS daemon. IPFS Cluster provides data orchestration across a swarm of IPFS daemons by allocating, replicating, and tracking a global pin-set distributed among multiple peers. This makes it significantly easier to manage multiple IPFS nodes and ensure that data is available across an internal network.
 
 IPFS Cluster is a distributed application that works as a sidecar to IPFS peers, maintaining a global cluster pinset and intelligently allocating its items to the IPFS peers. This makes it significantly easier to manage multiple IPFS nodes and ensure that data is available across an internal network. IPFS Cluster powers large IPFS storage services like [nft.storage](https://nft.storage/) and [web3.storage](https://web3.storage/). 
 
@@ -44,7 +44,7 @@ _No central server to manage:_ Cluster peers form a distributed network and main
 To see if IPFS Cluster is suitable for your project, follow this quick start guide and spin up a local IPFS Cluster instance. At the end of this guide, you will have a solid understanding of how IPFS Cluster is set up and how to interact with it. To create a local cluster, complete the prerequisites. Then, follow the procedure.
 
 :::tip
-If you'd rather create a production-ready cluster, take a look at the [official IPFS Cluster documentation →](https://cluster.ipfs.io/)
+If you'd rather create a production-ready cluster, take a look at the [official IPFS Cluster documentation →](https://ipfscluster.io/)
 :::
 
 ### Prerequisites
@@ -207,4 +207,4 @@ If you're having issues installing or using Docker or Docker-Compose, see the [o
 
 ## Next steps
 
-If you want to delve deeper into IPFS Cluster, check out the project's documentation at [cluster.ipfs.io →](https://cluster.ipfs.io/)
+If you want to delve deeper into IPFS Cluster, check out the project's documentation at [ipfscluster.io →](https://ipfscluster.io/)


### PR DESCRIPTION
Wanted to add missing-but-important "Mainnet" projects (Boxo, Rainbow, Someguy) to `/install` page, but realized the information architecture was pretty outdated and not very intuitive, so I've separated it into three sections:

1. User-Friendly Options
2. Command-Line & Infrastructure Tools
3. Software Development

This should make it easier for user visiting https://docs.ipfs.tech/install to make choice what to read, and what to skip + help ecosystem with people using Kubo for everything because they don't know better alternatives.

Updated various navigation and content links and applied minor fixes along the way.

cc @mishmosh @2color 