### PR TITLE
chore: update Dockerfile to use go1.23

### DIFF
--- a/.github/actions/latest-kubo-tag/Dockerfile
+++ b/.github/actions/latest-kubo-tag/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.23
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y jq && rm -rf /var/lib/apt/lists/*

--- a/.github/actions/update-with-latest-versions/Dockerfile
+++ b/.github/actions/update-with-latest-versions/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.23
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y jq && rm -rf /var/lib/apt/lists/*

--- a/tools/http-api-docs/go.mod
+++ b/tools/http-api-docs/go.mod
@@ -1,8 +1,6 @@
 module http-api-docs
 
-go 1.22
-
-toolchain go1.22.2
+go 1.23
 
 require (
 	github.com/Stebalien/go-json-doc v0.0.2


### PR DESCRIPTION
Needed to fix build error:
```
 github.com/ipfs/kubo@v0.31.0 requires go >= 1.23 (running go 1.22.8; GOTOOLCHAIN=local)
 ```
 