### PR TITLE
fix: troubleshooting.md

### DIFF
--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -101,13 +101,13 @@ If you feel intrepid, you can dump this information and investigate it yourself:
 1. goroutine dump:
 
     ```shell
-    curl localhost:5001/debug/pprof/goroutine\?debug=2 > ipfs.stacks`
+    curl localhost:5001/debug/pprof/goroutine\?debug=2 > ipfs.stacks
     ```
 
 1. 30-second cpu profile:
 
     ```shell
-    curl localhost:5001/debug/pprof/profile > ipfs.cpuprof`
+    curl localhost:5001/debug/pprof/profile > ipfs.cpuprof
     ```
 
 1. heap trace dump:
@@ -125,7 +125,7 @@ If you feel intrepid, you can dump this information and investigate it yourself:
 1. System information:
 
     ```shell
-    ipfs diag sys > ipfs.sysinfo`
+    ipfs diag sys > ipfs.sysinfo
     ```
 
 ### Analyzing the stack dump


### PR DESCRIPTION
Fixed bad markup that I saw at https://docs.ipfs.tech/how-to/troubleshooting/#go-debugging - for example, the command won't run if you try to run it verbatim as it escapes to next line or whatever in Bash/shell:
```
$ curl localhost:5001/debug/pprof/profile > ipfs.cpuprof`
> 
> ^C
$
```

<s>BTW, I can't run the Kubo ipfs daemon anymore, it's stuck here for more than an hour
```
$ ipfs daemon
Initializing daemon... \ Kubo version: 0.30.0
Repo version: 16 \ System version: amd64/linux
Golang version: go1.22.7 \ PeerID: ...
2024/11/17 03:41:29 failed to sufficiently increase receive buffer size
(was: 208 kiB, wanted: 7168 kiB, got: 416 kiB).
See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for details.
```
and never reaches "Daemon is ready". Maybe if I update Kubo that will fix it...</s> Restarting the computer and updating to Kubo 0.32.1 mysteriously fixed it. Hope I don't have this problem again!