### PR TITLE
docs(kubo-rps): describe JSONL returned by /api/vo/dag/import

### DIFF
--- a/docs/reference/kubo/rpc.md
+++ b/docs/reference/kubo/rpc.md
@@ -1102,22 +1102,11 @@ Argument `path` is of file type. This endpoint expects one or several files (dep
 
 ### Response
 
-On success, the call to this endpoint will return with 200 and the following body:
+On success, the call to this endpoint will return with 200 and the following JSONL body (if the `stats=true` argument is included):
 
 ```json
-{
-  "Root": {
-    "Cid": {
-      "/": "<cid-string>"
-    },
-    "PinErrorMsg": "<string>"
-  },
-  "Stats": {
-    "BlockBytesCount": "<uint64>",
-    "BlockCount": "<uint64>"
-  }
-}
-
+{"Root":{"Cid":{"/":"<cid-string>"},"PinErrorMsg":"string"}}
+{"Stats":{"BlockCount":<uint64>,"BlockBytesCount":<uint64>}}
 ```
 
 ### cURL Example


### PR DESCRIPTION
# Describe your changes
As described in #1980, the JSON body for the `/api/v0/dag/import` command is actually JSONL is the `stats=true` argument is included.


# Files changed

- docs/reference/kubo/rpc.md

# What issue(s) does this address?

#1980

- 
- 
- 

# Does this update depend on any other PRs?

No

- 
- 

## Checklist before requesting a review
- [ ] Passing the beta version of the **Check Markdown links for modified files** check. Action results can be viewed [here](https://github.com/ipfs/ipfs-docs/actions/workflows/action.yml).

## Checklist before merging
- [ ] Passing all required checks (The beta **Check Markdown links for modified files** check is not required)
