### PR TITLE
Add folder to IPFS - helpful details

### DIFF
--- a/tools/http-api-docs/markdown.go
+++ b/tools/http-api-docs/markdown.go
@@ -350,7 +350,7 @@ Argument `+"`%s`"+` is of file type. This endpoint expects one or several files 
 		if bodyArg.Endpoint == "/api/v0/add" {
 			fmt.Fprintln(buf, `
 
-The `+"`add`"+` command not only allows adding files, but also uploading directories and complex hierarchies. (For example, in cURL, you can upload multiple files and have them show up in a folder by running `+"`curl -sLk -XPOST -F \"file=@file1.txt;filename=path1/file1.txt\" -F \"file=@file2.txt;filename=path2/file2.txt\" \"http://127.0.0.1:5001/api/v0/add?recursive=true&wrap-with-directory=true\"`"+`.)
+The `+"`add`"+` command not only allows adding files, but also uploading directories and complex hierarchies. (For example, in cURL, you can upload multiple files and have them show up in a folder by running `+"`curl -sLk -XPOST -F \"file=@file1.txt;filename=path1/file1.txt\" -F \"file=@file2.txt;filename=path2/file2.txt\" \"http://127.0.0.1:5001/api/v0/add?recursive=true&wrap-with-directory=true\"`"+`; -F is specified multiple times along with recursive and wrap-with-directory.)
 
 This happens as follows: Every part in the multipart request is a *directory* or a *file* to be added to IPFS.
 

--- a/tools/http-api-docs/markdown.go
+++ b/tools/http-api-docs/markdown.go
@@ -350,7 +350,7 @@ Argument `+"`%s`"+` is of file type. This endpoint expects one or several files 
 		if bodyArg.Endpoint == "/api/v0/add" {
 			fmt.Fprintln(buf, `
 
-The `+"`add`"+` command not only allows adding files, but also uploading directories and complex hierarchies.
+The `+"`add`"+` command not only allows adding files, but also uploading directories and complex hierarchies. (For example, in cURL, you can upload multiple files and have them show up in a folder by running `+"`curl -sLk -XPOST -F \"file=@file1.txt;filename=path1/file1.txt\" -F \"file=@file2.txt;filename=path2/file2.txt\" \"http://127.0.0.1:5001/api/v0/add?recursive=true&wrap-with-directory=true\"`"+`.)
 
 This happens as follows: Every part in the multipart request is a *directory* or a *file* to be added to IPFS.
 


### PR DESCRIPTION
# Describe your changes
Adds an example on how to add a directory (not just a single file) by using curl and `/api/v0/add`. API docs are pretty clear as I've read about all of the page. The one unclear part is about adding folders.

# Files changed
- ipfs-docs/blob/main/tools/http-api-docs/markdown.go

# What issue(s) does this address?
- None. No GitHub issue/PR on this found. Maybe similar to adding directories: https://github.com/ipfs/ipfs-docs/issues/704 . About that, as far as I know, the only way to add a folder by using /api/v0/add is to specify one or multiple files plus the options in this PR. You cannot have a path to a folder and expect /api/v0/add to work. Or can you? (Something <b>like</b> `curl -XPOST -F "file=@folder/;filename=folder" 127.0.0.1:5001/api/v0/add`?) The documentation is unclear and this PR helps to fix that.

# Does this update depend on any other PRs?
- No

## Checklist before requesting a review
- [x] Passing the beta version of the **Check Markdown links for modified files** check. Action results can be viewed [here](https://github.com/ipfs/ipfs-docs/actions/workflows/action.yml).

## Checklist before merging
- [ ] Passing all required checks (The beta **Check Markdown links for modified files** check is not required)
