### PR TITLE
remove Scaleway labs from list of providers

### DIFF
--- a/docs/how-to/work-with-pinning-services.md
+++ b/docs/how-to/work-with-pinning-services.md
@@ -46,7 +46,6 @@ Third-party pinning services allow you to purchase pinning capacity for importan
 - [Filebase](https://filebase.com/)
 - [Storacha (formerly web3.storage)](https://storacha.network/)
 - [Infura](https://infura.io/)
-- [Scaleway](https://labs.scaleway.com/en/ipfs-pinning/)
 
 ::: callout 
 As of June 2023, [Filebase](https://filebase.com) and [Pinata](https://pinata.cloud/) support the [IPFS Pinning Service API endpoint](https://github.com/ipfs/pinning-services-api-spec).


### PR DESCRIPTION


# Describe your changes

I've removed Scaleway Labs from the list of pinning service providers.
The service has been discontinued: https://labs.scaleway.com/en/ipfs-pinning/#the-end


# Files changed
- docs/how-to/work-with-pinning-services.md

# What issue(s) does this address?

none

# Does this update depend on any other PRs?

none

## Checklist before requesting a review
- [ ] Passing the beta version of the **Check Markdown links for modified files** check. Action results can be viewed [here](https://github.com/ipfs/ipfs-docs/actions/workflows/action.yml).

## Checklist before merging
- [ ] Passing all required checks (The beta **Check Markdown links for modified files** check is not required)
