### PR TITLE
ci: modernize workflows to support fork pr previews

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,28 +1,38 @@
-name: Build and Deploy to IPFS
+# Build workflow - runs for both PRs and main branch pushes
+# This workflow builds the website without access to secrets
+# For PRs: Runs on untrusted fork code safely (using pull_request event, not pull_request_target)
+# For main: Builds and uploads artifacts for deployment
+# Artifacts are passed to the deploy workflow which has access to secrets
+
+name: Build
 
 permissions:
   contents: read
-  pull-requests: write
-  statuses: write
+
 on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
 
+env:
+  BUILD_PATH: 'docs/.vuepress/dist'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-    outputs: # This exposes the CID output of the action to the rest of the workflow
-      cid: ${{ steps.deploy.outputs.cid }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+        # No ref parameter needed - uses correct ref automatically:
+        # - For PRs: merge commit or PR head
+        # - For pushes: the pushed commit
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -31,16 +41,15 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefer-offline --no-audit --progress=false
 
       - name: Build project
         run: npm run docs:build
 
-      - uses: ipfs/ipfs-deploy-action@v1
-        name: Deploy to IPFS
-        id: deploy
+      # Upload artifact for deploy workflow
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
         with:
-          path-to-deploy: docs/.vuepress/dist
-          storacha-key: ${{ secrets.STORACHA_KEY }}
-          storacha-proof: ${{ secrets.STORACHA_PROOF }}
-          github-token: ${{ github.token }}
+          name: docs-build-${{ github.run_id }}
+          path: ${{ env.BUILD_PATH }}
+          retention-days: 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+# Deploy workflow - triggered by workflow_run after successful build
+# This workflow has access to secrets but never executes untrusted code
+# It only downloads and deploys pre-built artifacts from the build workflow
+# Security: Fork code cannot access secrets as it only runs in build workflow
+# Deploys to IPFS for all branches
+
+name: Deploy
+
+# Explicitly declare permissions
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+
+env:
+  BUILD_PATH: 'docs-build'
+
+jobs:
+  deploy-ipfs:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      cid: ${{ steps.deploy.outputs.cid }}
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-build-${{ github.event.workflow_run.id }}
+          path: ${{ env.BUILD_PATH }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Deploy to IPFS
+        uses: ipfs/ipfs-deploy-action@b491fdc2b1ca70a9b11b1a26dd4d36210c46653f # ipfs-deploy-action/pull/37
+        id: deploy
+        with:
+          path-to-deploy: ${{ env.BUILD_PATH }}
+          storacha-key: ${{ secrets.STORACHA_KEY }}
+          storacha-proof: ${{ secrets.STORACHA_PROOF }}
+          github-token: ${{ github.token }}
+
+      # TODO: Add DNSLink update when needed
+      #- name: Update DNSLink
+      #  if: github.event.workflow_run.head_branch == 'main'
+      #  uses: ipfs/dnslink-action@v0.1
+      #  with:
+      #    cid: ${{ steps.deploy.outputs.cid }}
+      #    dnslink_domain: 'docs.ipfs.tech'
+      #    cf_record_id: ${{ secrets.CF_RECORD_ID }}
+      #    cf_zone_id: ${{ secrets.CF_ZONE_ID }}
+      #    cf_auth_token: ${{ secrets.CF_AUTH_TOKEN }}
+      #    github_token: ${{ github.token }}
+      #    set_github_status: true


### PR DESCRIPTION
splits workflow to enable ipfs deployments for all pull requests including those from forks

- build.yml: builds site and uploads artifacts
- deploy.yml: handles ipfs deployment via workflow_run
- uses ipfs-deploy-action@b491fdc with workflow_run support from https://github.com/ipshipyard/ipfs-deploy-action/pull/37
