### PR TITLE
docs: use explicit /ipfs/ paths in name publish examples

### DIFF
--- a/docs/how-to/publish-ipns.md
+++ b/docs/how-to/publish-ipns.md
@@ -71,7 +71,7 @@ IPNS names can be published programmatically.
    > added bafkreidbbor7mvra2xzzl4kmr2sxrtkzaxlzs6rsr5ktgmbtousuzrhlxq hello.txt
    > 17 B / 17 B [=====================================================] 100.00%
 
-   ipfs name publish bafkreidbbor7mvra2xzzl4kmr2sxrtkzaxlzs6rsr5ktgmbtousuzrhlxq
+   ipfs name publish /ipfs/bafkreidbbor7mvra2xzzl4kmr2sxrtkzaxlzs6rsr5ktgmbtousuzrhlxq
 
    > Published to k51qzi5uqu5dgy6fu9073kabgj2nuq3qyo4f2rcnn4380z6n8i4v2lvo8dln6l: /ipfs/bafkreidbbor7mvra2xzzl4kmr2sxrtkzaxlzs6rsr5ktgmbtousuzrhlxq
    ```


### PR DESCRIPTION
# Describe your changes
This PR makes the `ipfs name publish` examples in the IPNS publishing tutorial
consistent by always using explicit `/ipfs/<CID>` paths.

The tutorial previously mixed bare CIDs and explicit paths. While Kubo accepts
a bare CID and implicitly treats it as `/ipfs/<CID>`, IPNS records conceptually
always point to paths. Using the explicit form throughout the document improves
conceptual clarity and helps you understand how IPNS resolution works.

This is a documentation-only change and does not affect CLI behavior.


# Files changed
- docs/how-to/publish-ipns.md

# What issue(s) does this address?

- N/A (documentation consistency improvement)

# Does this update depend on any other PRs?

- None

## Checklist before requesting a review
- [x] Passing the beta version of the **Check Markdown links for modified files** check. Action results can be viewed [here](https://github.com/ipfs/ipfs-docs/actions/workflows/action.yml).

## Checklist before merging
- [ ] Passing all required checks (The beta **Check Markdown links for modified files** check is not required)
