### PR TITLE
chore: replace broken docs.libp2p.io links with Internet Archive

### DIFF
--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -3,7 +3,7 @@ title: Glossary
 sidebarDepth: 0
 description: A glossary guide to key terminology for IPFS, the InterPlanetary File System.
 related:
-  'Guide to libp2p terminology': https://docs.libp2p.io/reference/glossary/
+  'Guide to libp2p terminology': https://web.archive.org/web/20260130120408/https://docs.libp2p.io/reference/glossary/
   'Guide to IPLD terminology': https://ipld.io/glossary/
   'IPFS Course at ProtoSchool': https://proto.school/course/ipfs
 ---
@@ -104,7 +104,7 @@ Version 1 (v1) of the IPFS content identifier. This CID version contains some le
 
 ### Circuit relay
 
-A [libp2p](#libp2p) term for transport protocol that routes traffic between two peers over a third-party [_relay_ peer](#relay-node). [More about Circuit Relay](https://docs.libp2p.io/concepts/circuit-relay/).
+A [libp2p](#libp2p) term for transport protocol that routes traffic between two peers over a third-party [_relay_ peer](#relay-node). [More about Circuit Relay](https://web.archive.org/web/20260128152445/https://docs.libp2p.io/concepts/nat/circuit-relay/).
 
 ### Circuit relay v1
 
@@ -364,11 +364,11 @@ The Multiformats project is a collection of protocols that aim to future-proof s
 
 ### Multiplexer
 
-Multiplexing allows for the creation of multiple “virtual” connections within a single [libp2p](#libp2p) connection. [More about Stream Multiplexing in libp2p docs](https://docs.libp2p.io/concepts/multiplex/overview/)
+Multiplexing allows for the creation of multiple "virtual" connections within a single [libp2p](#libp2p) connection. [More about Stream Multiplexing in libp2p docs](https://web.archive.org/web/20260128163648/https://docs.libp2p.io/concepts/multiplex/overview/)
 
 ### Mplex
 
-mplex is a deprecated stream multiplexer that was designed in the early days of [libp2p](#libp2p). [More about mplex](https://docs.libp2p.io/concepts/multiplex/mplex/)
+mplex is a deprecated stream multiplexer that was designed in the early days of [libp2p](#libp2p). [More about mplex](https://web.archive.org/web/20250624193954/https://docs.libp2p.io/concepts/multiplex/mplex/)
 
 ## N
 
@@ -404,7 +404,7 @@ In system architecture, a Peer is an equal player in the peer-to-peer model of d
 
 ### Peer routing
 
-Peer routing is the process of discovering the network _route_ or address for a network peer using various methods. The primary peer routing mechanism in IPFS is a distributed hash table that uses the [Kademlia routing algorithm](dht.md#lookup-algorithm) to efficiently locate peers. However, other methods, like local discovery, are also used. Learn more in the [libp2p documentation](https://docs.libp2p.io/concepts/).
+Peer routing is the process of discovering the network _route_ or address for a network peer using various methods. The primary peer routing mechanism in IPFS is a distributed hash table that uses the [Kademlia routing algorithm](dht.md#lookup-algorithm) to efficiently locate peers. However, other methods, like local discovery, are also used. Learn more in the [libp2p documentation](https://web.archive.org/web/20251113174247/https://docs.libp2p.io/concepts/).
 
 ### Peer ID
 
@@ -438,7 +438,7 @@ Publish-subscribe (Pubsub) is an experimental feature in IPFS. Publishers send m
 
 ### QUIC
 
-QUIC (`/quic-v1`) is one of [libp2p](#libp2p) [transport](#transport) protocols. It provides an always-encrypted, stream-multiplexed connection built on top of UDP. [More about QUIC in libp2p](https://docs.libp2p.io/concepts/transports/quic/)
+QUIC (`/quic-v1`) is one of [libp2p](#libp2p) [transport](#transport) protocols. It provides an always-encrypted, stream-multiplexed connection built on top of UDP. [More about QUIC in libp2p](https://web.archive.org/web/20260128152146/https://docs.libp2p.io/concepts/transports/quic/)
 
 ## R
 
@@ -452,7 +452,7 @@ In IPFS context, the practice of [pinning](#pinning) the same content to multipl
 
 ### Relay node
 
-A means to establish connectivity between libp2p nodes (e.g., IPFS nodes) that wouldn't otherwise be able to establish a direct connection to each other. This may be due to nodes that are behind NAT (Network Address Translation), reverse proxies, firewalls, etc. See [Nodes > Relay](../concepts/nodes.md#relay) and [libp2p docs about Circuit Relay](https://docs.libp2p.io/concepts/nat/circuit-relay/).
+A means to establish connectivity between libp2p nodes (e.g., IPFS nodes) that wouldn't otherwise be able to establish a direct connection to each other. This may be due to nodes that are behind NAT (Network Address Translation), reverse proxies, firewalls, etc. See [Nodes > Relay](../concepts/nodes.md#relay) and [libp2p docs about Circuit Relay](https://web.archive.org/web/20260128152445/https://docs.libp2p.io/concepts/nat/circuit-relay/).
 
 ### Remote Pinning
 
@@ -518,7 +518,7 @@ _Swarm_ is a term for the network of IPFS peers with which your local node has c
 
 In [libp2p](#libp2p), a _switch_ is a component responsible for composing multiple [transports](#transport) into a single interface, allowing application code to [dial](#dialing) peers without having to specify which transport to use.
 
-Switches also coordinate the _connection upgrade_ process, which promotes a _raw_ connection from the transport layer into one that supports [protocol negotiation](https://docs.libp2p.io/concepts/protocols/#protocol-negotiation), [stream multiplexing](../concepts/libp2p.md#stream-multiplexing), and secure communications.
+Switches also coordinate the _connection upgrade_ process, which promotes a _raw_ connection from the transport layer into one that supports [protocol negotiation](https://web.archive.org/web/20260113172348/https://docs.libp2p.io/concepts/protocols/#protocol-negotiation), [stream multiplexing](../concepts/libp2p.md#stream-multiplexing), and secure communications.
 
 Sometimes called [swarm](#swarm) for historical reasons.
 
@@ -526,7 +526,7 @@ Sometimes called [swarm](#swarm) for historical reasons.
 
 ### Transport
 
-In [libp2p](#libp2p), transport refers to the technology that lets us move data from one machine to another. This may be a TCP, UDP ([QUIC](#quic)) network, a [WebSocket](#websocket) connection in a browser, or anything else capable of implementing the transport interface. [More about libp2p transports](https://docs.libp2p.io/concepts/transports/overview/)
+In [libp2p](#libp2p), transport refers to the technology that lets us move data from one machine to another. This may be a TCP, UDP ([QUIC](#quic)) network, a [WebSocket](#websocket) connection in a browser, or anything else capable of implementing the transport interface. [More about libp2p transports](https://web.archive.org/web/20260128152051/https://docs.libp2p.io/concepts/transports/overview/)
 
 ### Traversal
 
@@ -556,7 +556,7 @@ Wide Area Network (WAN) is a type of (usually public) computer network that span
 
 ### WebRTC
 
-WebRTC (Web Real-Time Communications) is a framework for real-time communication and in libp2p is used to establish browser-to-server and browser-to-browser connections between applications. [Libp2p](#libp2p) supports WebRTC as multiple [transports](#transport) (`/webrtc`, `/webrtc-direct`). [More about WebRTC in libp2p](https://docs.libp2p.io/concepts/transports/webrtc/)
+WebRTC (Web Real-Time Communications) is a framework for real-time communication and in libp2p is used to establish browser-to-server and browser-to-browser connections between applications. [Libp2p](#libp2p) supports WebRTC as multiple [transports](#transport) (`/webrtc`, `/webrtc-direct`). [More about WebRTC in libp2p](https://web.archive.org/web/20260128152341/https://docs.libp2p.io/concepts/transports/webrtc/)
 
 ### WebSocket
 
@@ -564,7 +564,7 @@ WebSockets are a way for web applications to maintain bidirectional communicatio
 
 ### WebTransport
 
-WebTransport is a new specification that uses QUIC to offer an alternative to [WebSocket](#websocket). Conceptually, it can be considered WebSocket over [QUIC](#quic). [Libp2p](#libp2p) supports is indicated by `/webtransport` [Multiaddr](#multiaddr). [More about WebTransport in libp2p](https://docs.libp2p.io/concepts/transports/webtransport/)
+WebTransport is a new specification that uses QUIC to offer an alternative to [WebSocket](#websocket). Conceptually, it can be considered WebSocket over [QUIC](#quic). [Libp2p](#libp2p) supports is indicated by `/webtransport` [Multiaddr](#multiaddr). [More about WebTransport in libp2p](https://web.archive.org/web/20260128152314/https://docs.libp2p.io/concepts/transports/webtransport/)
 
 ## X
 
@@ -572,6 +572,6 @@ WebTransport is a new specification that uses QUIC to offer an alternative to [W
 
 ### Yamux
 
-Yamux (Yet another Multiplexer) is a powerful stream [multiplexer](#multiplexer) used in [libp2p](#libp2p). [More about Yamux in libp2p docs](https://docs.libp2p.io/concepts/multiplex/yamux/)
+Yamux (Yet another Multiplexer) is a powerful stream [multiplexer](#multiplexer) used in [libp2p](#libp2p). [More about Yamux in libp2p docs](https://web.archive.org/web/20250917025649/https://docs.libp2p.io/concepts/multiplex/yamux/)
 
 ## Z

--- a/docs/concepts/ipns.md
+++ b/docs/concepts/ipns.md
@@ -110,7 +110,7 @@ graph TB
     Publisher-- Cache -->Local-. GET .->Resolver-- Cache -->Local
 ```
 
-The self-certifying nature of IPNS records means that they are not tied to a specific transport protocol. In practice, most IPFS implementations rely on the [**DHT**](dht.md) and [**libp2p PubSub**](https://docs.libp2p.io/concepts/publish-subscribe/) to publish and resolve IPNS records.
+The self-certifying nature of IPNS records means that they are not tied to a specific transport protocol. In practice, most IPFS implementations rely on the [**DHT**](dht.md) and [**libp2p PubSub**](https://web.archive.org/web/20250827093310/https://docs.libp2p.io/concepts/publish-subscribe/) to publish and resolve IPNS records.
 
 There are nuanced differences and trade-offs between the **DHT** and **PubSub** to be aware of.
 
@@ -139,7 +139,7 @@ It's worth noting that publishing and resolving IPNS names using the DHT can be 
 
 #### IPNS over PubSub
 
-IPNS over PubSub uses the [Libp2p PubSub](https://docs.libp2p.io/concepts/publish-subscribe/) to publish records and resolve names amongst **interested peers**.
+IPNS over PubSub uses the [Libp2p PubSub](https://web.archive.org/web/20250827093310/https://docs.libp2p.io/concepts/publish-subscribe/) to publish records and resolve names amongst **interested peers**.
 
 This is achieved by deriving the PubSub topic name from the IPNS name so that each IPNS name has a unique topic.
 

--- a/docs/concepts/libp2p.md
+++ b/docs/concepts/libp2p.md
@@ -3,9 +3,9 @@ title: libp2p
 sidebarDepth: 0
 description: Learn about the libp2p protocol and why it's an important ingredient in how IPFS works.
 related:
-  'What is libp2p?': https://docs.libp2p.io/concepts/introduction/overview/
-  'Foundational libp2p concepts': https://docs.libp2p.io/concepts/
-  'Getting started with libp2p': https://docs.libp2p.io/guides/
+  'What is libp2p?': https://web.archive.org/web/20260119023244/https://docs.libp2p.io/concepts/introduction/overview/
+  'Foundational libp2p concepts': https://web.archive.org/web/20251113174247/https://docs.libp2p.io/concepts/
+  'Getting started with libp2p': https://web.archive.org/web/20250624052058/https://docs.libp2p.io/guides/
 ---
 
 # libp2p
@@ -44,19 +44,19 @@ libp2p was designed to address these limitations.
 
 ## Features
 
-The features of libp2p are listed below. For more information on each feature, click the link to navigate to the appropriate page in the [official libp2p documentation](https://docs.libp2p.io).
+The features of libp2p are listed below. For more information on each feature, click the link to navigate to the appropriate page in the [official libp2p documentation](https://web.archive.org/web/20260128151944/https://docs.libp2p.io/).
 
-- [Flexible addressing](https://docs.libp2p.io/concepts/addressing/)
+- [Flexible addressing](https://web.archive.org/web/20251224030222/https://docs.libp2p.io/concepts/addressing/)
 
-- [Transport agnostic](https://docs.libp2p.io/concepts/transports/overview/)
+- [Transport agnostic](https://web.archive.org/web/20260128152051/https://docs.libp2p.io/concepts/transports/overview/)
 
-- [Customizable security](https://docs.libp2p.io/concepts/secure-comm/overview/)
+- [Customizable security](https://web.archive.org/web/20250624052827/https://docs.libp2p.io/concepts/secure-comm/overview/)
 
-- [Peer identity](https://docs.libp2p.io/concepts/fundamentals/peers/#peer-id)
+- [Peer identity](https://web.archive.org/web/20251112181025/https://docs.libp2p.io/concepts/fundamentals/peers/#peer-id)
 
-- [Peer routing](https://docs.libp2p.io/concepts/appendix/glossary/#peer-routing)
+- [Peer routing](https://web.archive.org/web/20260130063617/https://docs.libp2p.io/concepts/appendix/glossary/#peer-routing)
 
-- [NAT traversal](https://docs.libp2p.io/concepts/nat/)
+- [NAT traversal](https://web.archive.org/web/20260115071913/https://docs.libp2p.io/concepts/nat/)
 
 ### Publish/subscribe
 
@@ -64,13 +64,13 @@ _Publish/Subscribe_ (PubSub) is a messaging model where peers congregate around 
 
 One of the key challenges in P2P-based PubSub systems is the prompt and efficient delivery of messages to all subscribers, especially in large and dynamic networks. To overcome these challenges, IPFS utilizes libp2p's _GossipSub_ protocol, which operates by "gossiping" with peers about the messages they have received, enabling an efficient message delivery network.
 
-Check out the [libp2p documentation](https://docs.libp2p.io/concepts/pubsub/overview/) to learn more about PubSub in libp2p.
+Check out the [libp2p documentation](https://web.archive.org/web/20260116065034/https://docs.libp2p.io/concepts/pubsub/overview/) to learn more about PubSub in libp2p.
 
 ## Additional resources
 
-- [The libp2p documentation](https://docs.libp2p.io/)
+- [The libp2p documentation](https://web.archive.org/web/20260128151944/https://docs.libp2p.io/)
 - [The libp2p website](https://libp2p.io/)
-- [The libp2p connectivity site](https://connectivity.libp2p.io/)
+- [The libp2p connectivity site](https://web.archive.org/web/20251118040510/https://connectivity.libp2p.io/)
 - [The libp2p YouTube channel to libp2p](https://www.youtube.com/@libp2p630)
 - [The libp2p technical specifications](https://github.com/libp2p/specs)
 - [Protocol Labs Research - ResNetLab on Tour](https://research.protocol.ai/tutorials/resnetlab-on-tour/)

--- a/docs/how-to/webtransport.md
+++ b/docs/how-to/webtransport.md
@@ -5,7 +5,7 @@ description: Learn how your files are broken down into blocks in IPFS and how to
 
 # WebTransport and Kubo
 
-[WebTransport](https://docs.libp2p.io/concepts/transports/webtransport/), a new libp2p transport protocol, allows browsers to contact [Kubo](../install/command-line.md) nodes, so instead of serving requests for other system level application nodes, you can serve requests directly to a browser. This guide will explain how WebTransport works, Kubo-WebTransport integration use cases, and how to get started with WebTransport in Kubo.
+[WebTransport](https://web.archive.org/web/20260128152314/https://docs.libp2p.io/concepts/transports/webtransport/), a new libp2p transport protocol, allows browsers to contact [Kubo](../install/command-line.md) nodes, so instead of serving requests for other system level application nodes, you can serve requests directly to a browser. This guide will explain how WebTransport works, Kubo-WebTransport integration use cases, and how to get started with WebTransport in Kubo.
 
 Kubo v0.16 introduced [optional support for WebTransport](https://github.com/ipfs/kubo/releases?q=0.16.0&expanded=true#-webtransport-new-experimental-transport), and Kubo v0.18 [enabled support by default](https://github.com/ipfs/kubo/blob/release-v0.18/docs/changelogs/v0.18.md#webtransport-enabled-by-default).  
 
@@ -46,6 +46,6 @@ To get started with using WebTransport with Kubo, you can use follow this GitHub
 
 You can learn more about WebTransport with the following resources:
 
-- [libp2p documentation: WebTransport](https://docs.libp2p.io/concepts/transports/webtransport/)
-- [connectivity.libp2p.io](https://connectivity.libp2p.io/#webtransport)
+- [libp2p documentation: WebTransport](https://web.archive.org/web/20260128152314/https://docs.libp2p.io/concepts/transports/webtransport/)
+- [connectivity.libp2p.io](https://web.archive.org/web/20251118040510/https://connectivity.libp2p.io/#webtransport)
 - [WebTransport spec](https://github.com/libp2p/specs/tree/master/webtransport)


### PR DESCRIPTION
swap to last working snapshots until libp2p project fixes their docs website.

they missed the window of fleek migration and all docs.libp2p.io links are broken at the time of writing:
- https://web.archive.org/web/20260201063701/https://docs.libp2p.io/
- the new portal has different URLs and there is no redirect, so users get errors

cc @aschmahmann @mishmosh for visibility. parking as draft for now, but if its libp2p docs portal is dead for more than a week, or old links are not fixed to redirect to new URLs, we should merge this.

